### PR TITLE
Add YAML config support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,16 +99,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -139,6 +167,47 @@ name = "risu-rs"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -163,6 +232,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.9"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,54 @@
-/// Generate a configuration file optionally based on a template
-pub fn generate(template: Option<&str>) {
-    if let Some(t) = template {
-        println!("Generating config from template: {}", t);
-    } else {
-        println!("Generating default configuration");
+use serde::{Deserialize, Serialize};
+use std::{fs, path::Path};
+
+/// Application configuration loaded from a YAML file.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    /// URL of the database to connect to.
+    #[serde(default = "default_database_url")]
+    pub database_url: String,
+    /// Logging level used by the application.
+    #[serde(default = "default_log_level")]
+    pub log_level: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            database_url: default_database_url(),
+            log_level: default_log_level(),
+        }
     }
+}
+
+fn default_database_url() -> String {
+    "sqlite://:memory:".to_string()
+}
+
+fn default_log_level() -> String {
+    "info".to_string()
+}
+
+/// Write a configuration file containing default values to the given path.
+pub fn create_config(path: &Path) -> std::io::Result<()> {
+    let cfg = Config::default();
+    let yaml = serde_yaml::to_string(&cfg).expect("serialize default config");
+    fs::write(path, yaml)
+}
+
+/// Load configuration from the given path, falling back to defaults when
+/// values are missing or empty.
+pub fn load_config(path: &Path) -> Result<Config, Box<dyn std::error::Error>> {
+    let raw = fs::read_to_string(path)?;
+    let mut cfg: Config = serde_yaml::from_str(&raw).unwrap_or_default();
+
+    if cfg.database_url.trim().is_empty() {
+        cfg.database_url = default_database_url();
+    }
+    if cfg.log_level.trim().is_empty() {
+        cfg.log_level = default_log_level();
+    }
+
+    Ok(cfg)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Generate a configuration file
-    CreateConfig {
-        /// Optional template to base the config on
-        #[arg(long)]
-        template: Option<String>,
-    },
+    /// Generate a configuration file with default values
+    CreateConfig,
     /// Run database migrations
     Migrate {
         /// Create tables in the database
@@ -40,8 +36,11 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::CreateConfig { template } => {
-            config::generate(template.as_deref());
+        Commands::CreateConfig => {
+            let path = std::path::Path::new("config.yml");
+            if let Err(e) = config::create_config(path) {
+                eprintln!("failed to write config: {e}");
+            }
         }
         Commands::Migrate {
             create_tables,


### PR DESCRIPTION
## Summary
- add serde and serde_yaml for configuration serialization
- provide Config struct with defaults and load/create helpers
- expose `create_config` command to generate default `config.yml`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a94101f26083209ea4917a33e29ffc