### PR TITLE
Expose template helper utilities as Rust modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,6 +1314,7 @@ name = "risu-rs"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "base64",
  "chrono",
  "clap",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ inventory = "0.3"
 csv = "1.3"
 plotters = { version = "0.3", features = ["full_palette"] }
 rand = "0.8"
+base64 = "0.21"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod banner;
+pub mod config;
+pub mod graphs;
+pub mod migrate;
+pub mod models;
+pub mod parser;
+pub mod postprocess;
+pub mod renderer;
+pub mod schema;
+pub mod template;

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -11,6 +11,8 @@ use libloading::{Library, Symbol};
 
 use crate::{graphs, parser::NessusReport, renderer::Renderer};
 
+pub mod helpers;
+
 /// Trait implemented by report templates.
 pub trait Template {
     /// Name used to reference the template.


### PR DESCRIPTION
## Summary
- add helper functions `unsupported_os`, `heading2`, and `embed_graph` for templates
- expose helpers through `TemplateManager` and new `lib.rs`
- cover helpers with unit tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aa6c11b6288320961adf6ccde69402