### PR TITLE
Add NASL plugin indexing subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,9 +1327,11 @@ dependencies = [
  "printpdf",
  "quick-xml",
  "rand",
+ "regex",
  "serde",
  "serde_yaml",
  "tempfile",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ csv = "1.3"
 plotters = { version = "0.3", features = ["full_palette"] }
 rand = "0.8"
 base64 = "0.21"
+regex = "1.10"
+walkdir = "2.5"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/migrations/00000000000002_create_plugin_metadata/down.sql
+++ b/migrations/00000000000002_create_plugin_metadata/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE nessus_plugin_metadata;

--- a/migrations/00000000000002_create_plugin_metadata/up.sql
+++ b/migrations/00000000000002_create_plugin_metadata/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE nessus_plugin_metadata (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    script_id INTEGER,
+    script_name TEXT,
+    cve TEXT,
+    bid TEXT
+);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod postprocess;
 mod renderer;
 mod schema;
 mod template;
+mod plugin_index;
 
 use clap::{Parser, Subcommand};
 
@@ -55,6 +56,11 @@ enum Commands {
         /// Run post-processing plugins on the parsed data
         #[arg(long)]
         post_process: bool,
+    },
+    /// Index NASL plugins and store metadata
+    PluginIndex {
+        /// Directory containing NASL plugins
+        dir: std::path::PathBuf,
     },
 }
 
@@ -132,5 +138,10 @@ fn main() {
                 eprintln!("failed to parse file: {e}");
             }
         },
+        Commands::PluginIndex { dir } => {
+            if let Err(e) = plugin_index::run(&dir) {
+                eprintln!("failed to index plugins: {e}");
+            }
+        }
     }
 }

--- a/src/plugin_index.rs
+++ b/src/plugin_index.rs
@@ -1,0 +1,94 @@
+use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
+use diesel_migrations::MigrationHarness;
+use regex::Regex;
+use walkdir::WalkDir;
+
+use crate::migrate::MIGRATIONS;
+use crate::schema::nessus_plugin_metadata;
+
+#[derive(Insertable)]
+#[diesel(table_name = nessus_plugin_metadata)]
+struct NewPluginMetadata<'a> {
+    script_id: i32,
+    script_name: &'a str,
+    cve: Option<&'a str>,
+    bid: Option<&'a str>,
+}
+
+pub fn run(dir: &std::path::Path) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let database_url = "risu.db";
+    let mut conn = SqliteConnection::establish(database_url)?;
+    conn.run_pending_migrations(MIGRATIONS)?;
+
+    // clear existing entries
+    diesel::delete(nessus_plugin_metadata::table).execute(&mut conn)?;
+
+    let re_id = Regex::new(r"(?m)script_id\s*\(\s*([0-9]+)\s*\)")?;
+    let re_name = Regex::new(r#"(?m)script_name\s*\(\s*\"([^\"]+)\""#)?;
+    let re_xref =
+        Regex::new(r#"(?m)script_xref\s*\(\s*name\s*:\s*\"([^\"]+)\"\s*,\s*value\s*:\s*\"([^\"]+)\""#)?;
+
+    let mut processed = 0;
+    let mut inserted = 0;
+
+    for entry in WalkDir::new(dir).into_iter().filter_map(|e| e.ok()) {
+        if entry.file_type().is_file()
+            && entry.path().extension().and_then(|s| s.to_str()) == Some("nasl")
+        {
+            processed += 1;
+            let content = match std::fs::read_to_string(entry.path()) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let id_cap = match re_id.captures(&content) {
+                Some(c) => c,
+                None => continue,
+            };
+            let name_cap = match re_name.captures(&content) {
+                Some(c) => c,
+                None => continue,
+            };
+            let script_id: i32 = id_cap[1].parse().unwrap_or(0);
+            let script_name = name_cap[1].trim();
+
+            let mut cves = Vec::new();
+            let mut bids = Vec::new();
+            for cap in re_xref.captures_iter(&content) {
+                match &cap[1] {
+                    "CVE" => cves.push(cap[2].to_string()),
+                    "BID" => bids.push(cap[2].to_string()),
+                    _ => {}
+                }
+            }
+            let cve_str = if cves.is_empty() {
+                None
+            } else {
+                Some(cves.join(","))
+            };
+            let bid_str = if bids.is_empty() {
+                None
+            } else {
+                Some(bids.join(","))
+            };
+
+            let new_md = NewPluginMetadata {
+                script_id,
+                script_name,
+                cve: cve_str.as_deref(),
+                bid: bid_str.as_deref(),
+            };
+            diesel::insert_into(nessus_plugin_metadata::table)
+                .values(&new_md)
+                .execute(&mut conn)?;
+            inserted += 1;
+            println!("Indexed plugin {} ({})", script_id, script_name);
+        }
+    }
+
+    println!(
+        "Processed {} plugin files, inserted {} records",
+        processed, inserted
+    );
+    Ok(())
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -110,9 +110,20 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    nessus_plugin_metadata (id) {
+        id -> Integer,
+        script_id -> Nullable<Integer>,
+        script_name -> Nullable<Text>,
+        cve -> Nullable<Text>,
+        bid -> Nullable<Text>,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     nessus_hosts,
     nessus_host_properties,
     nessus_items,
     nessus_plugins,
+    nessus_plugin_metadata,
 );


### PR DESCRIPTION
## Summary
- add `plugin-index` CLI to scan NASL plugin directories
- parse script ID, name, CVE and BID xrefs and populate `nessus_plugin_metadata`
- create migration and schema for plugin metadata

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aa70cdefe0832089209fa3b19930e2