### PR TITLE
Add nil renderer and CLI option

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -96,3 +96,28 @@ impl Renderer for CsvRenderer {
         Ok(())
     }
 }
+
+/// Renderer that discards all output. Useful for benchmarking or tests where
+/// rendering is unnecessary.
+pub struct NilRenderer;
+
+impl NilRenderer {
+    /// Create a new `NilRenderer`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Renderer for NilRenderer {
+    fn text(&mut self, _text: &str) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+
+    fn start_new_page(&mut self) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+
+    fn save(&mut self, _writer: &mut dyn Write) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -34,3 +34,38 @@ fn create_config_and_parse() {
         .success();
     assert!(output.exists());
 }
+
+#[test]
+fn parse_with_nil_renderer_creates_no_file() {
+    let tmp = tempdir().unwrap();
+    let sample = fs::canonicalize("tests/fixtures/sample.nessus").unwrap();
+
+    // create config
+    Command::cargo_bin("risu-rs")
+        .unwrap()
+        .args(["--no-banner", "create-config"])
+        .current_dir(&tmp)
+        .assert()
+        .success();
+    assert!(tmp.path().join("config.yml").exists());
+
+    // parse file with nil renderer
+    let output = tmp.path().join("out.pdf");
+    Command::cargo_bin("risu-rs")
+        .unwrap()
+        .current_dir(&tmp)
+        .args([
+            "--no-banner",
+            "parse",
+            sample.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "-t",
+            "simple",
+            "--renderer",
+            "nil",
+        ])
+        .assert()
+        .success();
+    assert!(!output.exists());
+}


### PR DESCRIPTION
## Summary
- add no-op NilRenderer
- allow selecting renderer via `--renderer`, including `nil`
- test nil renderer doesn't create output files

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7673bc44832083528f9c72147aae