### PR TITLE
Add basic built-in templates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod postprocess;
 pub mod renderer;
 pub mod schema;
 pub mod template;
+pub mod templates;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod postprocess;
 mod renderer;
 mod schema;
 mod template;
+mod templates;
 
 use clap::{Parser, Subcommand};
 use tracing::error;
@@ -122,6 +123,8 @@ fn run() -> Result<(), error::Error> {
                 .collect();
             let mut manager = template::TemplateManager::new(paths);
             manager.register(Box::new(template::SimpleTemplate));
+            manager.register(Box::new(templates::TemplateTemplate));
+            manager.register(Box::new(templates::HostSummaryTemplate));
             manager.load_templates().map_err(error::Error::Template)?;
             let tmpl = manager.get(&tmpl_name).ok_or_else(|| {
                 error::Error::Config(format!(

--- a/src/templates/host_summary.rs
+++ b/src/templates/host_summary.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+
+use crate::parser::NessusReport;
+use crate::renderer::Renderer;
+use crate::template::Template;
+
+/// Rough port of the Host Summary report from the Ruby implementation.
+pub struct HostSummaryTemplate;
+
+impl Template for HostSummaryTemplate {
+    fn name(&self) -> &str {
+        "host_summary"
+    }
+
+    fn generate(
+        &self,
+        report: &NessusReport,
+        renderer: &mut dyn Renderer,
+    ) -> Result<(), Box<dyn Error>> {
+        renderer.text("Host Summary Report")?;
+        renderer.text(&format!("Total Hosts: {}", report.hosts.len()))?;
+        for host in &report.hosts {
+            let name = host.name.as_deref().unwrap_or("unknown");
+            renderer.text(&format!("Host: {name}"))?;
+        }
+        Ok(())
+    }
+}

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -1,0 +1,5 @@
+pub mod template;
+pub mod host_summary;
+
+pub use host_summary::HostSummaryTemplate;
+pub use template::TemplateTemplate;

--- a/src/templates/template.rs
+++ b/src/templates/template.rs
@@ -1,0 +1,23 @@
+use std::error::Error;
+
+use crate::parser::NessusReport;
+use crate::renderer::Renderer;
+use crate::template::Template;
+
+/// Basic example template ported from the original Ruby implementation.
+pub struct TemplateTemplate;
+
+impl Template for TemplateTemplate {
+    fn name(&self) -> &str {
+        "template"
+    }
+
+    fn generate(
+        &self,
+        _report: &NessusReport,
+        renderer: &mut dyn Renderer,
+    ) -> Result<(), Box<dyn Error>> {
+        renderer.text("Template")?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add modules for `template` and `host_summary` built-in reports
- wire new templates into template manager

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aa78c2aa208320b58c9a56c98a3a40