### PR TITLE
Embed template assets

### DIFF
--- a/src/template/helpers.rs
+++ b/src/template/helpers.rs
@@ -1,7 +1,4 @@
 use std::error::Error;
-use std::fs;
-use std::path::Path;
-
 use base64::{engine::general_purpose, Engine};
 
 /// Produce a message indicating the operating system is unsupported.
@@ -15,8 +12,9 @@ pub fn heading2(text: &str) -> String {
 }
 
 /// Embed a graph image as a base64 data URI.
-pub fn embed_graph(path: &Path) -> Result<String, Box<dyn Error>> {
-    let bytes = fs::read(path)?;
+///
+/// The image bytes are expected to be in PNG format.
+pub fn embed_graph(bytes: &[u8]) -> Result<String, Box<dyn Error>> {
     let encoded = general_purpose::STANDARD.encode(bytes);
     Ok(format!("data:image/png;base64,{encoded}"))
 }
@@ -24,8 +22,6 @@ pub fn embed_graph(path: &Path) -> Result<String, Box<dyn Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
-    use std::io::Write;
 
     #[test]
     fn unsupported_os_message() {
@@ -39,10 +35,8 @@ mod tests {
     }
 
     #[test]
-    fn embed_graph_encodes_file() {
-        let mut file = NamedTempFile::new().unwrap();
-        file.write_all(&[1u8, 2, 3]).unwrap();
-        let data = embed_graph(file.path()).unwrap();
+    fn embed_graph_encodes_bytes() {
+        let data = embed_graph(&[1u8, 2, 3]).unwrap();
         assert!(data.starts_with("data:image/png;base64,"));
         let b64 = &data["data:image/png;base64,".len()..];
         let expected = general_purpose::STANDARD.encode(&[1u8, 2, 3]);

--- a/src/templates/assets/mod.rs
+++ b/src/templates/assets/mod.rs
@@ -1,0 +1,37 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Raw bytes of a tiny embedded logo image.
+///
+/// The image is a 1x1 transparent PNG encoded directly in the source to avoid
+/// storing binary files in the repository.
+pub const LOGO_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00, 0x00, 0xB5, 0x1C, 0x0C,
+    0x02, 0x00, 0x00, 0x00, 0x0B, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+    0x42, 0x60, 0x82,
+];
+
+/// Access the embedded logo image bytes.
+pub fn logo_png() -> &'static [u8] {
+    LOGO_PNG
+}
+
+/// Write the embedded logo image to the system temporary directory and return
+/// the path to the written file.
+pub fn write_logo_png() -> io::Result<PathBuf> {
+    let mut path = std::env::temp_dir();
+    path.push("logo.png");
+    fs::write(&path, LOGO_PNG)?;
+    Ok(path)
+}
+
+/// Write the embedded logo image into the provided directory.
+/// Returns the full path of the written file.
+pub fn write_logo_png_to(dir: &Path) -> io::Result<PathBuf> {
+    let path = dir.join("logo.png");
+    fs::write(&path, LOGO_PNG)?;
+    Ok(path)
+}

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -1,3 +1,4 @@
+pub mod assets;
 pub mod template;
 pub mod host_summary;
 

--- a/src/templates/template.rs
+++ b/src/templates/template.rs
@@ -2,7 +2,8 @@ use std::error::Error;
 
 use crate::parser::NessusReport;
 use crate::renderer::Renderer;
-use crate::template::Template;
+use crate::template::{self, Template};
+use crate::templates::assets;
 
 /// Basic example template ported from the original Ruby implementation.
 pub struct TemplateTemplate;
@@ -18,6 +19,11 @@ impl Template for TemplateTemplate {
         renderer: &mut dyn Renderer,
     ) -> Result<(), Box<dyn Error>> {
         renderer.text("Template")?;
+        // Demonstrate embedding an image from the bundled assets directory.
+        // The image bytes are included in the binary and encoded as a data URI
+        // for renderers that accept inline images.
+        let logo_data_uri = template::helpers::embed_graph(assets::logo_png())?;
+        renderer.text(&logo_data_uri)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- add `templates::assets` module embedding a tiny inline logo image and file helpers
- reference embedded image from example template and update helpers to base64 encode bytes

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8413862883209043078840669257