### PR TITLE
Add PCI, STIG, and SSL cipher templates

### DIFF
--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -1,6 +1,12 @@
 pub mod assets;
-pub mod template;
 pub mod host_summary;
+pub mod pci_compliance;
+pub mod ssl_medium_str_cipher_support;
+pub mod stig_findings_summary;
+pub mod template;
 
 pub use host_summary::HostSummaryTemplate;
+pub use pci_compliance::PCIComplianceTemplate;
+pub use ssl_medium_str_cipher_support::SslMediumStrCipherSupportTemplate;
+pub use stig_findings_summary::StigFindingsSummaryTemplate;
 pub use template::TemplateTemplate;

--- a/src/templates/pci_compliance.rs
+++ b/src/templates/pci_compliance.rs
@@ -1,0 +1,51 @@
+use std::error::Error;
+
+use crate::parser::NessusReport;
+use crate::renderer::Renderer;
+use crate::template::Template;
+
+/// Simplified PCI compliance overview template.
+pub struct PCIComplianceTemplate;
+
+impl Template for PCIComplianceTemplate {
+    fn name(&self) -> &str {
+        "pci_compliance"
+    }
+
+    fn generate(
+        &self,
+        report: &NessusReport,
+        renderer: &mut dyn Renderer,
+    ) -> Result<(), Box<dyn Error>> {
+        renderer.text("PCI / DSS Compliance Overview")?;
+        renderer.text(&format!("Total Hosts: {}", report.hosts.len()))?;
+
+        // Naively look for plugin 33929 and classify output containing
+        // "passed" or "failed".
+        let mut passed = 0;
+        let mut failed = 0;
+        for item in &report.items {
+            if item.plugin_id == Some(33929) {
+                if item
+                    .plugin_output
+                    .as_deref()
+                    .map(|o| o.to_lowercase().contains("passed"))
+                    .unwrap_or(false)
+                {
+                    passed += 1;
+                } else if item
+                    .plugin_output
+                    .as_deref()
+                    .map(|o| o.to_lowercase().contains("failed"))
+                    .unwrap_or(false)
+                {
+                    failed += 1;
+                }
+            }
+        }
+
+        renderer.text(&format!("Hosts passed: {passed}"))?;
+        renderer.text(&format!("Hosts failed: {failed}"))?;
+        Ok(())
+    }
+}

--- a/src/templates/ssl_medium_str_cipher_support.rs
+++ b/src/templates/ssl_medium_str_cipher_support.rs
@@ -1,0 +1,33 @@
+use std::error::Error;
+
+use crate::parser::NessusReport;
+use crate::renderer::Renderer;
+use crate::template::Template;
+
+/// Lists SSL medium strength cipher findings.
+pub struct SslMediumStrCipherSupportTemplate;
+
+impl Template for SslMediumStrCipherSupportTemplate {
+    fn name(&self) -> &str {
+        "ssl_medium_str_cipher_support"
+    }
+
+    fn generate(
+        &self,
+        report: &NessusReport,
+        renderer: &mut dyn Renderer,
+    ) -> Result<(), Box<dyn Error>> {
+        renderer.text("SSL Medium Strength Cipher Support")?;
+        let mut count = 0;
+        for item in &report.items {
+            if let Some(name) = &item.plugin_name {
+                if name.to_lowercase().contains("ssl medium") {
+                    count += 1;
+                    renderer.text(name)?;
+                }
+            }
+        }
+        renderer.text(&format!("Total findings: {count}"))?;
+        Ok(())
+    }
+}

--- a/src/templates/stig_findings_summary.rs
+++ b/src/templates/stig_findings_summary.rs
@@ -1,0 +1,36 @@
+use std::error::Error;
+
+use crate::parser::NessusReport;
+use crate::renderer::Renderer;
+use crate::template::Template;
+
+/// Rough STIG findings summary template.
+pub struct StigFindingsSummaryTemplate;
+
+impl Template for StigFindingsSummaryTemplate {
+    fn name(&self) -> &str {
+        "stig_findings_summary"
+    }
+
+    fn generate(
+        &self,
+        report: &NessusReport,
+        renderer: &mut dyn Renderer,
+    ) -> Result<(), Box<dyn Error>> {
+        renderer.text("STIG Findings Summary")?;
+
+        // Summarize counts by severity level.
+        let mut counts = [0usize; 5];
+        for item in &report.items {
+            if let Some(sev) = item.severity {
+                if (0..5).contains(&sev) {
+                    counts[sev as usize] += 1;
+                }
+            }
+        }
+        for (sev, count) in counts.iter().enumerate() {
+            renderer.text(&format!("Severity {sev}: {count} findings"))?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add PCI compliance, STIG findings summary, and SSL medium strength cipher support templates
- expose templates via `--list-templates` flag and register for parsing

## Testing
- `cargo test`
- `cargo run -- --list-templates`

------
https://chatgpt.com/codex/tasks/task_e_68aaaabab7788320bb0e4bac9ce6caf0