### PR TITLE
Add host properties and service enumeration parsing

### DIFF
--- a/migrations/00000000000004_create_service_descriptions/down.sql
+++ b/migrations/00000000000004_create_service_descriptions/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE nessus_service_descriptions;

--- a/migrations/00000000000004_create_service_descriptions/up.sql
+++ b/migrations/00000000000004_create_service_descriptions/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE nessus_service_descriptions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    host_id INTEGER REFERENCES nessus_hosts(id),
+    item_id INTEGER REFERENCES nessus_items(id),
+    name TEXT,
+    port INTEGER,
+    protocol TEXT,
+    description TEXT,
+    user_id INTEGER,
+    engagement_id INTEGER
+);

--- a/migrations/00000000000005_create_attachments/down.sql
+++ b/migrations/00000000000005_create_attachments/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE nessus_attachments;

--- a/migrations/00000000000005_create_attachments/up.sql
+++ b/migrations/00000000000005_create_attachments/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE nessus_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    content_type TEXT,
+    path TEXT,
+    size INTEGER
+);

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,7 +8,10 @@ use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use std::net::IpAddr;
 
-use crate::schema::{nessus_hosts, nessus_items, nessus_patches, nessus_plugins};
+use crate::schema::{
+    nessus_host_properties, nessus_hosts, nessus_items, nessus_patches, nessus_plugins,
+    nessus_service_descriptions,
+};
 
 #[derive(Debug, Queryable, Identifiable)]
 #[diesel(table_name = nessus_hosts)]
@@ -27,6 +30,31 @@ pub struct Host {
     pub risk_score: Option<i32>,
     pub user_id: Option<i32>,
     pub engagement_id: Option<i32>,
+}
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Host, foreign_key = host_id))]
+#[diesel(table_name = nessus_host_properties)]
+pub struct HostProperty {
+    pub id: i32,
+    pub host_id: Option<i32>,
+    pub name: Option<String>,
+    pub value: Option<String>,
+    pub user_id: Option<i32>,
+    pub engagement_id: Option<i32>,
+}
+
+impl Default for HostProperty {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            host_id: None,
+            name: None,
+            value: None,
+            user_id: None,
+            engagement_id: None,
+        }
+    }
 }
 
 #[derive(Debug, Queryable, Identifiable, Associations)]
@@ -156,6 +184,38 @@ pub struct Patch {
     pub value: Option<String>,
     pub user_id: Option<i32>,
     pub engagement_id: Option<i32>,
+}
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Host, foreign_key = host_id))]
+#[diesel(belongs_to(Item, foreign_key = item_id))]
+#[diesel(table_name = nessus_service_descriptions)]
+pub struct ServiceDescription {
+    pub id: i32,
+    pub host_id: Option<i32>,
+    pub item_id: Option<i32>,
+    pub name: Option<String>,
+    pub port: Option<i32>,
+    pub protocol: Option<String>,
+    pub description: Option<String>,
+    pub user_id: Option<i32>,
+    pub engagement_id: Option<i32>,
+}
+
+impl Default for ServiceDescription {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            host_id: None,
+            item_id: None,
+            name: None,
+            port: None,
+            protocol: None,
+            description: None,
+            user_id: None,
+            engagement_id: None,
+        }
+    }
 }
 
 impl Default for Patch {

--- a/src/models.rs
+++ b/src/models.rs
@@ -9,8 +9,8 @@ use diesel::sqlite::SqliteConnection;
 use std::net::IpAddr;
 
 use crate::schema::{
-    nessus_host_properties, nessus_hosts, nessus_items, nessus_patches, nessus_plugins,
-    nessus_service_descriptions,
+    nessus_attachments, nessus_host_properties, nessus_hosts, nessus_items, nessus_patches,
+    nessus_plugins, nessus_service_descriptions,
 };
 
 #[derive(Debug, Queryable, Identifiable)]
@@ -30,6 +30,28 @@ pub struct Host {
     pub risk_score: Option<i32>,
     pub user_id: Option<i32>,
     pub engagement_id: Option<i32>,
+}
+
+#[derive(Debug, Queryable, Identifiable)]
+#[diesel(table_name = nessus_attachments)]
+pub struct Attachment {
+    pub id: i32,
+    pub name: Option<String>,
+    pub content_type: Option<String>,
+    pub path: Option<String>,
+    pub size: Option<i32>,
+}
+
+impl Default for Attachment {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            name: None,
+            content_type: None,
+            path: None,
+            size: None,
+        }
+    }
 }
 
 #[derive(Debug, Queryable, Identifiable, Associations)]
@@ -60,6 +82,7 @@ impl Default for HostProperty {
 #[derive(Debug, Queryable, Identifiable, Associations)]
 #[diesel(belongs_to(Host, foreign_key = host_id))]
 #[diesel(belongs_to(Plugin, foreign_key = plugin_id))]
+#[diesel(belongs_to(Attachment, foreign_key = attachment_id))]
 #[diesel(table_name = nessus_items)]
 pub struct Item {
     pub id: i32,

--- a/src/models.rs
+++ b/src/models.rs
@@ -314,7 +314,6 @@ mod tests {
     use super::*;
     use crate::migrate::MIGRATIONS;
     use crate::schema::nessus_hosts;
-    use diesel::prelude::*;
     use diesel::sqlite::SqliteConnection;
     use diesel_migrations::MigrationHarness;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,11 +3,12 @@
 use std::collections::BTreeSet;
 use std::path::Path;
 
-use quick_xml::Reader;
 use quick_xml::events::Event;
+use quick_xml::Reader;
 use tracing::{debug, info};
 
-use crate::models::{Host, HostProperty, Item, Patch, Plugin, ServiceDescription};
+use crate::models::{Host, Item, Patch, Plugin};
+use crate::models::{HostProperty, ServiceDescription};
 use regex::Regex;
 
 /// Parsed representation of a Nessus report.
@@ -274,13 +275,11 @@ mod tests {
         assert!(names.contains(&"ssh".to_string()));
         assert!(names.contains(&"http".to_string()));
         // item plugin output captured
-        assert!(
-            report.items[0]
-                .plugin_output
-                .as_ref()
-                .unwrap()
-                .contains("Credentialed Checks")
-        );
+        assert!(report.items[0]
+            .plugin_output
+            .as_ref()
+            .unwrap()
+            .contains("Credentialed Checks"));
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,8 @@ use quick_xml::Reader;
 use tracing::{debug, info};
 
 use crate::models::{Host, Item, Patch, Plugin};
-use crate::models::{HostProperty, ServiceDescription};
+use crate::models::HostProperty;
+use crate::models::ServiceDescription;
 use regex::Regex;
 
 /// Parsed representation of a Nessus report.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -111,6 +111,20 @@ diesel::table! {
 }
 
 diesel::table! {
+    nessus_service_descriptions (id) {
+        id -> Integer,
+        host_id -> Nullable<Integer>,
+        item_id -> Nullable<Integer>,
+        name -> Nullable<Text>,
+        port -> Nullable<Integer>,
+        protocol -> Nullable<Text>,
+        description -> Nullable<Text>,
+        user_id -> Nullable<Integer>,
+        engagement_id -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
     nessus_plugin_metadata (id) {
         id -> Integer,
         script_id -> Nullable<Integer>,
@@ -138,4 +152,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     nessus_plugins,
     nessus_plugin_metadata,
     nessus_patches,
+    nessus_service_descriptions,
 );

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -146,11 +146,11 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
-    nessus_hosts,
     nessus_host_properties,
+    nessus_hosts,
     nessus_items,
-    nessus_plugins,
     nessus_plugin_metadata,
+    nessus_plugins,
     nessus_patches,
     nessus_service_descriptions,
 );

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -149,8 +149,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     nessus_host_properties,
     nessus_hosts,
     nessus_items,
+    nessus_patches,
     nessus_plugin_metadata,
     nessus_plugins,
-    nessus_patches,
     nessus_service_descriptions,
 );

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -111,6 +111,16 @@ diesel::table! {
 }
 
 diesel::table! {
+    nessus_attachments (id) {
+        id -> Integer,
+        name -> Nullable<Text>,
+        content_type -> Nullable<Text>,
+        path -> Nullable<Text>,
+        size -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
     nessus_service_descriptions (id) {
         id -> Integer,
         host_id -> Nullable<Integer>,
@@ -146,6 +156,7 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+    nessus_attachments,
     nessus_host_properties,
     nessus_hosts,
     nessus_items,

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -13,6 +13,7 @@ use crate::{graphs, parser::NessusReport, renderer::Renderer};
 
 pub mod create;
 pub mod helpers;
+pub mod scan_helper;
 
 /// Trait implemented by report templates.
 pub trait Template {

--- a/src/template/scan_helper.rs
+++ b/src/template/scan_helper.rs
@@ -1,0 +1,73 @@
+use std::collections::{BTreeSet, HashMap};
+
+use crate::parser::NessusReport;
+
+/// Convert plugin output from the Nessus Scan Information plugin
+/// into a key/value map. Lines are expected to be in the form
+/// `Key: value`.
+fn scan_info_to_hash(output: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for line in output.lines() {
+        if let Some((k, v)) = line.split_once(':') {
+            map.insert(
+                k.trim().to_lowercase().replace(' ', "_"),
+                v.trim().to_lowercase(),
+            );
+        }
+    }
+    map
+}
+
+/// Count authenticated vs unauthenticated scans by examining
+/// plugin 19506 outputs.
+pub fn authenticated_count(report: &NessusReport) -> (usize, usize) {
+    let mut auth = 0usize;
+    let mut unauth = 0usize;
+    for item in &report.items {
+        if item.plugin_id == Some(19506) {
+            if let Some(ref out) = item.plugin_output {
+                let info = scan_info_to_hash(out);
+                if let Some(v) = info.get("credentialed_checks") {
+                    if v.contains("yes") {
+                        auth += 1;
+                    } else {
+                        unauth += 1;
+                    }
+                }
+            }
+        }
+    }
+    (auth, unauth)
+}
+
+/// List discovered services from service descriptions in the report.
+pub fn discovered_services(report: &NessusReport) -> BTreeSet<String> {
+    report
+        .service_descriptions
+        .iter()
+        .filter_map(|s| {
+            let name = s.name.as_ref()?;
+            let port = s.port?;
+            let proto = s.protocol.as_deref().unwrap_or("");
+            Some(format!("{name} {port}/{proto}"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::parse_file;
+    use std::path::Path;
+
+    #[test]
+    fn counts_and_services() {
+        let report = parse_file(Path::new("tests/fixtures/scaninfo.nessus")).unwrap();
+        let (auth, unauth) = authenticated_count(&report);
+        assert_eq!(auth, 1);
+        assert_eq!(unauth, 0);
+        let services = discovered_services(&report);
+        assert!(services.contains("ssh 22/tcp"));
+        assert!(services.contains("http 80/tcp"));
+    }
+}

--- a/tests/fixtures/scaninfo.nessus
+++ b/tests/fixtures/scaninfo.nessus
@@ -1,0 +1,16 @@
+<NessusClientData_v2 version="2.0">
+  <ReportHost name="192.168.0.1">
+    <HostProperties>
+      <tag name="host-ip">192.168.0.1</tag>
+      <tag name="Credentialed_Scan">true</tag>
+    </HostProperties>
+    <ReportItem pluginID="19506" port="0" svc_name="" protocol="tcp" severity="0" pluginName="Nessus Scan Information">
+      <plugin_output>
+Scanner IP: 10.0.0.5
+Credentialed Checks: yes
+22/tcp open ssh
+80/tcp open http
+      </plugin_output>
+    </ReportItem>
+  </ReportHost>
+</NessusClientData_v2>


### PR DESCRIPTION
## Summary
- map HostProperty and ServiceDescription models
- parse host properties and service enumeration (plugin 19506) into linked records
- add ScanHelper template utilities for authenticated scan counts and discovered services

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aab34f7a9c8320a23e88890454842e