### PR TITLE
Store and access Nessus host properties

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -5,8 +5,10 @@
 //! implemented at the moment.
 
 pub mod attachment;
+pub mod host_property;
 
 pub use attachment::Attachment;
+pub use host_property::HostProperty;
 
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;

--- a/src/models/host_property.rs
+++ b/src/models/host_property.rs
@@ -1,0 +1,29 @@
+use diesel::prelude::*;
+
+use crate::models::Host;
+use crate::schema::nessus_host_properties;
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Host, foreign_key = host_id))]
+#[diesel(table_name = nessus_host_properties)]
+pub struct HostProperty {
+    pub id: i32,
+    pub host_id: Option<i32>,
+    pub name: Option<String>,
+    pub value: Option<String>,
+    pub user_id: Option<i32>,
+    pub engagement_id: Option<i32>,
+}
+
+impl Default for HostProperty {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            host_id: None,
+            name: None,
+            value: None,
+            user_id: None,
+            engagement_id: None,
+        }
+    }
+}

--- a/src/parser/simple_nexpose.rs
+++ b/src/parser/simple_nexpose.rs
@@ -74,6 +74,7 @@ impl From<SimpleNexpose> for super::NessusReport {
             plugins: s.plugins,
             patches: Vec::new(),
             attachments: Vec::new(),
+            host_properties: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Model Nessus host properties in the database
- Parse <tag> elements into HostProperty records
- Expose template helpers to fetch host properties for a host

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab968daff483208d1882bac3ae3012