### PR TITLE
Add policy parsing and template helpers

### DIFF
--- a/migrations/00000000000005_create_policies/down.sql
+++ b/migrations/00000000000005_create_policies/down.sql
@@ -1,0 +1,5 @@
+DROP TABLE nessus_server_preferences;
+DROP TABLE nessus_plugin_preferences;
+DROP TABLE nessus_family_selections;
+DROP TABLE nessus_policy_plugins;
+DROP TABLE nessus_policies;

--- a/migrations/00000000000005_create_policies/up.sql
+++ b/migrations/00000000000005_create_policies/up.sql
@@ -1,0 +1,38 @@
+CREATE TABLE nessus_policies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    comments TEXT
+);
+
+CREATE TABLE nessus_policy_plugins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    policy_id INTEGER REFERENCES nessus_policies(id),
+    plugin_id INTEGER,
+    plugin_name TEXT,
+    family_name TEXT,
+    status TEXT
+);
+
+CREATE TABLE nessus_family_selections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    policy_id INTEGER REFERENCES nessus_policies(id),
+    family_name TEXT,
+    status TEXT
+);
+
+CREATE TABLE nessus_plugin_preferences (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    policy_id INTEGER REFERENCES nessus_policies(id),
+    plugin_id INTEGER,
+    fullname TEXT,
+    preference_name TEXT,
+    preference_type TEXT,
+    selected_value TEXT
+);
+
+CREATE TABLE nessus_server_preferences (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    policy_id INTEGER REFERENCES nessus_policies(id),
+    name TEXT,
+    value TEXT
+);

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,10 +7,20 @@
 pub mod attachment;
 pub mod host_property;
 pub mod service_description;
+pub mod policy;
+pub mod family_selection;
+pub mod plugin_preference;
+pub mod policy_plugin;
+pub mod server_preference;
 
 pub use attachment::Attachment;
 pub use host_property::HostProperty;
 pub use service_description::ServiceDescription;
+pub use policy::Policy;
+pub use family_selection::FamilySelection;
+pub use plugin_preference::PluginPreference;
+pub use policy_plugin::PolicyPlugin;
+pub use server_preference::ServerPreference;
 
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
@@ -264,7 +274,6 @@ mod tests {
     use super::*;
     use crate::migrate::MIGRATIONS;
     use crate::schema::nessus_hosts;
-    use diesel::prelude::*;
     use diesel::sqlite::SqliteConnection;
     use diesel_migrations::MigrationHarness;
 

--- a/src/models/family_selection.rs
+++ b/src/models/family_selection.rs
@@ -1,0 +1,20 @@
+use diesel::prelude::*;
+
+use crate::schema::nessus_family_selections;
+use super::Policy;
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Policy, foreign_key = policy_id))]
+#[diesel(table_name = nessus_family_selections)]
+pub struct FamilySelection {
+    pub id: i32,
+    pub policy_id: Option<i32>,
+    pub family_name: Option<String>,
+    pub status: Option<String>,
+}
+
+impl Default for FamilySelection {
+    fn default() -> Self {
+        Self { id: 0, policy_id: None, family_name: None, status: None }
+    }
+}

--- a/src/models/plugin_preference.rs
+++ b/src/models/plugin_preference.rs
@@ -1,0 +1,31 @@
+use diesel::prelude::*;
+
+use crate::schema::nessus_plugin_preferences;
+use super::Policy;
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Policy, foreign_key = policy_id))]
+#[diesel(table_name = nessus_plugin_preferences)]
+pub struct PluginPreference {
+    pub id: i32,
+    pub policy_id: Option<i32>,
+    pub plugin_id: Option<i32>,
+    pub fullname: Option<String>,
+    pub preference_name: Option<String>,
+    pub preference_type: Option<String>,
+    pub selected_value: Option<String>,
+}
+
+impl Default for PluginPreference {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            policy_id: None,
+            plugin_id: None,
+            fullname: None,
+            preference_name: None,
+            preference_type: None,
+            selected_value: None,
+        }
+    }
+}

--- a/src/models/policy.rs
+++ b/src/models/policy.rs
@@ -1,0 +1,17 @@
+use diesel::prelude::*;
+
+use crate::schema::nessus_policies;
+
+#[derive(Debug, Queryable, Identifiable)]
+#[diesel(table_name = nessus_policies)]
+pub struct Policy {
+    pub id: i32,
+    pub name: Option<String>,
+    pub comments: Option<String>,
+}
+
+impl Default for Policy {
+    fn default() -> Self {
+        Self { id: 0, name: None, comments: None }
+    }
+}

--- a/src/models/policy_plugin.rs
+++ b/src/models/policy_plugin.rs
@@ -1,0 +1,29 @@
+use diesel::prelude::*;
+
+use crate::schema::nessus_policy_plugins;
+use super::Policy;
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Policy, foreign_key = policy_id))]
+#[diesel(table_name = nessus_policy_plugins)]
+pub struct PolicyPlugin {
+    pub id: i32,
+    pub policy_id: Option<i32>,
+    pub plugin_id: Option<i32>,
+    pub plugin_name: Option<String>,
+    pub family_name: Option<String>,
+    pub status: Option<String>,
+}
+
+impl Default for PolicyPlugin {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            policy_id: None,
+            plugin_id: None,
+            plugin_name: None,
+            family_name: None,
+            status: None,
+        }
+    }
+}

--- a/src/models/server_preference.rs
+++ b/src/models/server_preference.rs
@@ -1,0 +1,20 @@
+use diesel::prelude::*;
+
+use crate::schema::nessus_server_preferences;
+use super::Policy;
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Policy, foreign_key = policy_id))]
+#[diesel(table_name = nessus_server_preferences)]
+pub struct ServerPreference {
+    pub id: i32,
+    pub policy_id: Option<i32>,
+    pub name: Option<String>,
+    pub value: Option<String>,
+}
+
+impl Default for ServerPreference {
+    fn default() -> Self {
+        Self { id: 0, policy_id: None, name: None, value: None }
+    }
+}

--- a/src/parser/simple_nexpose.rs
+++ b/src/parser/simple_nexpose.rs
@@ -77,6 +77,11 @@ impl From<SimpleNexpose> for super::NessusReport {
             attachments: Vec::new(),
             host_properties: Vec::new(),
             service_descriptions: s.service_descriptions,
+            policies: Vec::new(),
+            policy_plugins: Vec::new(),
+            family_selections: Vec::new(),
+            plugin_preferences: Vec::new(),
+            server_preferences: Vec::new(),
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -18,6 +18,55 @@ diesel::table! {
 }
 
 diesel::table! {
+    nessus_policies (id) {
+        id -> Integer,
+        name -> Nullable<Text>,
+        comments -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    nessus_policy_plugins (id) {
+        id -> Integer,
+        policy_id -> Nullable<Integer>,
+        plugin_id -> Nullable<Integer>,
+        plugin_name -> Nullable<Text>,
+        family_name -> Nullable<Text>,
+        status -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    nessus_family_selections (id) {
+        id -> Integer,
+        policy_id -> Nullable<Integer>,
+        family_name -> Nullable<Text>,
+        status -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    nessus_plugin_preferences (id) {
+        id -> Integer,
+        policy_id -> Nullable<Integer>,
+        plugin_id -> Nullable<Integer>,
+        fullname -> Nullable<Text>,
+        preference_name -> Nullable<Text>,
+        preference_type -> Nullable<Text>,
+        selected_value -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    nessus_server_preferences (id) {
+        id -> Integer,
+        policy_id -> Nullable<Integer>,
+        name -> Nullable<Text>,
+        value -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
     nessus_host_properties (id) {
         id -> Integer,
         host_id -> Nullable<Integer>,
@@ -164,4 +213,9 @@ diesel::allow_tables_to_appear_in_same_query!(
     nessus_service_descriptions,
     nessus_plugin_metadata,
     nessus_patches,
+    nessus_policies,
+    nessus_policy_plugins,
+    nessus_family_selections,
+    nessus_plugin_preferences,
+    nessus_server_preferences,
 );


### PR DESCRIPTION
## Summary
- mirror Nessus policy models (policy, family selections, plugin preferences, policy plugins, server preferences)
- parse `<Policy>` sections to populate policy data and plugin/family/preference information
- add template helpers for enabled families/plugins and server preferences

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68aba147fd9c8320a80b7895041c453f