### PR TITLE
feat: add downgrade plugin postprocess and tests

### DIFF
--- a/src/postprocess/downgrade_plugins.rs
+++ b/src/postprocess/downgrade_plugins.rs
@@ -1,0 +1,40 @@
+use super::{PluginEntry, PostProcess, PostProcessInfo};
+use crate::parser::NessusReport;
+
+struct DowngradePlugins;
+
+impl PostProcess for DowngradePlugins {
+    fn info(&self) -> PostProcessInfo {
+        PostProcessInfo {
+            name: "downgrade_plugins",
+            order: 45,
+        }
+    }
+
+    fn run(&self, report: &mut NessusReport) {
+        for (plugin_id, severity) in PLUGINS_TO_SEVERITY {
+            for item in &mut report.items {
+                if item.plugin_id == Some(*plugin_id) {
+                    item.severity = Some(*severity);
+                }
+            }
+        }
+    }
+}
+
+inventory::submit! {
+    PluginEntry { plugin: &DowngradePlugins }
+}
+
+const PLUGINS_TO_SEVERITY: &[(i32, i32)] = &[
+    (41028, 0), // SNMP Agent Default Community Name (public)
+    (10264, 0), // SNMP Agent Default Community Names
+    (10081, 0), // FTP Privileged Port Bounce Scan
+    (42411, 0), // Microsoft Windows SMB Shares Unprivileged Access
+    (66349, 0), // X Server Unauthenticated Access: Screenshot
+    (26925, 0), // VNC Server Unauthenticated Access
+    (66174, 0), // VNC Server Unauthenticated Access: Screenshot
+    (10205, 0), // rlogin Service Detection
+    (20007, 2), // SSL Version 2 and 3 Protocol Detection
+    (80101, 2), // IPMI v2.0 Password Hash Disclosure
+];

--- a/src/postprocess/mod.rs
+++ b/src/postprocess/mod.rs
@@ -89,6 +89,7 @@ pub fn list() -> Vec<PostProcessInfo> {
     infos
 }
 
+mod downgrade_plugins;
 mod fix_ips;
 mod normalize_plugin_names;
 mod risk_score;

--- a/tests/postprocess.rs
+++ b/tests/postprocess.rs
@@ -1,0 +1,110 @@
+use risu_rs::models::{Host, Item, Plugin};
+use risu_rs::parser::NessusReport;
+use risu_rs::postprocess;
+
+fn host(name: &str, ip: Option<&str>) -> Host {
+    Host {
+        id: 0,
+        nessus_report_id: None,
+        name: Some(name.to_string()),
+        os: None,
+        mac: None,
+        start: None,
+        end: None,
+        ip: ip.map(|s| s.to_string()),
+        fqdn: None,
+        netbios: None,
+        notes: None,
+        risk_score: None,
+        user_id: None,
+        engagement_id: None,
+    }
+}
+
+#[test]
+fn fix_ips_sets_missing_ip() {
+    let mut report = NessusReport {
+        hosts: vec![host("10.0.0.1", None)],
+        ..NessusReport::default()
+    };
+    postprocess::process(&mut report);
+    assert_eq!(report.hosts[0].ip.as_deref(), Some("10.0.0.1"));
+}
+
+#[test]
+fn sort_hosts_orders_by_ip() {
+    let mut report = NessusReport {
+        hosts: vec![
+            host("host2", Some("10.0.0.2")),
+            host("host1", Some("10.0.0.1")),
+        ],
+        ..NessusReport::default()
+    };
+    postprocess::process(&mut report);
+    assert_eq!(report.hosts[0].ip.as_deref(), Some("10.0.0.1"));
+    assert_eq!(report.hosts[1].ip.as_deref(), Some("10.0.0.2"));
+}
+
+#[test]
+fn normalize_plugin_names_sanitizes_strings() {
+    let mut plugin = Plugin::default();
+    plugin.plugin_name = Some("Example (POODLE)".to_string());
+    let mut report = NessusReport {
+        plugins: vec![plugin],
+        ..NessusReport::default()
+    };
+    postprocess::process(&mut report);
+    assert_eq!(report.plugins[0].plugin_name.as_deref(), Some("Example"));
+}
+
+#[test]
+fn root_cause_sets_known_plugins() {
+    let mut plugin = Plugin::default();
+    plugin.plugin_id = Some(22194);
+    let mut report = NessusReport {
+        plugins: vec![plugin],
+        ..NessusReport::default()
+    };
+    postprocess::process(&mut report);
+    assert_eq!(
+        report.plugins[0].root_cause.as_deref(),
+        Some("Vendor Patch")
+    );
+}
+
+#[test]
+fn risk_score_computes_scores() {
+    let host = host("host", Some("10.0.0.1"));
+    let mut plugin = Plugin::default();
+    plugin.plugin_id = Some(1);
+    plugin.cvss_base_score = Some(5.0);
+    let mut item = Item::default();
+    item.plugin_id = Some(1);
+    let mut report = NessusReport {
+        hosts: vec![host],
+        plugins: vec![plugin],
+        items: vec![item],
+        ..NessusReport::default()
+    };
+    postprocess::process(&mut report);
+    assert_eq!(report.items[0].risk_score, Some(4));
+    assert_eq!(report.plugins[0].risk_score, Some(4));
+    assert_eq!(report.hosts[0].risk_score, Some(4));
+}
+
+#[test]
+fn downgrade_plugins_adjusts_severity() {
+    let mut item1 = Item::default();
+    item1.plugin_id = Some(41028);
+    item1.severity = Some(3);
+    let mut item2 = Item::default();
+    item2.plugin_id = Some(20007);
+    item2.severity = Some(4);
+    let mut report = NessusReport {
+        items: vec![item1, item2],
+        ..NessusReport::default()
+    };
+    postprocess::process(&mut report);
+    assert_eq!(report.items[0].severity, Some(0));
+    assert_eq!(report.items[1].severity, Some(2));
+}


### PR DESCRIPTION
## Summary
- port downgrade_plugins post-process from Ruby and register with inventory
- add unit tests covering post-process plugins and new downgrade_plugins behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abb2feca948320a7f534cf25645cd5