### PR TITLE
feat(cli): support configurable config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Rust rewrite of the Risu reporting utilities.
 ## Command-line usage
 
 ```bash
-risu-rs create-config              # write default config.yml
+risu-rs --create-config-file       # write default config.yml
 risu-rs migrate --create-tables    # run database migrations
 risu-rs parse scan.nessus -o report.csv -t simple --post-process
 risu-rs parse scan.nessus -o report.pdf -t simple --template-arg title="Custom Title"
@@ -15,7 +15,7 @@ risu-rs --list-post-process        # list post-process plugins
 
 ## Configuration
 
-Settings are read from `config.yml`:
+Settings are read from a YAML file (default: `config.yml`):
 
 ```yaml
 database_url: sqlite://:memory:

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,12 @@ fn default_template_paths() -> Vec<String> {
 
 /// Write a configuration file containing default values to the given path.
 pub fn create_config(path: &Path) -> Result<(), crate::error::Error> {
+    if path.exists() {
+        return Err(crate::error::Error::Config(format!(
+            "configuration file '{}' already exists",
+            path.display()
+        )));
+    }
     let cfg = Config::default();
     let yaml = serde_yaml::to_string(&cfg)?;
     fs::write(path, yaml)?;
@@ -67,6 +73,12 @@ pub fn create_config(path: &Path) -> Result<(), crate::error::Error> {
 /// Load configuration from the given path, falling back to defaults when
 /// values are missing or empty.
 pub fn load_config(path: &Path) -> Result<Config, crate::error::Error> {
+    if !path.exists() {
+        return Err(crate::error::Error::Config(format!(
+            "configuration file '{}' not found",
+            path.display()
+        )));
+    }
     let raw = fs::read_to_string(path)?;
     let mut cfg: Config = serde_yaml::from_str(&raw).unwrap_or_default();
 

--- a/src/console.rs
+++ b/src/console.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use crate::{config, error, models};
 
-pub fn run() -> Result<(), error::Error> {
-    let cfg = config::load_config(Path::new("config.yml")).unwrap_or_default();
+pub fn run(config_path: &Path) -> Result<(), error::Error> {
+    let cfg = config::load_config(config_path).unwrap_or_default();
     let mut dconn = SqliteConnection::establish(&cfg.database_url)?;
     let db_path = cfg
         .database_url

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,7 +10,7 @@ fn create_config_and_parse() {
     // create config
     Command::cargo_bin("risu-rs")
         .unwrap()
-        .args(["--no-banner", "create-config"])
+        .args(["--no-banner", "--create-config-file"])
         .current_dir(&tmp)
         .assert()
         .success();
@@ -23,6 +23,8 @@ fn create_config_and_parse() {
         .current_dir(&tmp)
         .args([
             "--no-banner",
+            "--config-file",
+            "config.yml",
             "parse",
             sample.to_str().unwrap(),
             "-o",
@@ -43,7 +45,7 @@ fn parse_with_nil_renderer_creates_no_file() {
     // create config
     Command::cargo_bin("risu-rs")
         .unwrap()
-        .args(["--no-banner", "create-config"])
+        .args(["--no-banner", "--create-config-file"])
         .current_dir(&tmp)
         .assert()
         .success();
@@ -56,6 +58,8 @@ fn parse_with_nil_renderer_creates_no_file() {
         .current_dir(&tmp)
         .args([
             "--no-banner",
+            "--config-file",
+            "config.yml",
             "parse",
             sample.to_str().unwrap(),
             "-o",
@@ -100,7 +104,7 @@ fn template_arg_overrides_title() {
     // create config
     Command::cargo_bin("risu-rs")
         .unwrap()
-        .args(["--no-banner", "create-config"])
+        .args(["--no-banner", "--create-config-file"])
         .current_dir(&tmp)
         .assert()
         .success();
@@ -111,6 +115,8 @@ fn template_arg_overrides_title() {
         .current_dir(&tmp)
         .args([
             "--no-banner",
+            "--config-file",
+            "config.yml",
             "parse",
             sample.to_str().unwrap(),
             "-o",


### PR DESCRIPTION
## Summary
- allow specifying config file path with `--config-file`
- generate default config with `--create-config-file [path]`
- better errors when config file is missing or already exists

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abc486ea588320bb10ee260b879b85