### PR TITLE
Add Nexpose XML parser

### DIFF
--- a/src/parser/nexpose/mod.rs
+++ b/src/parser/nexpose/mod.rs
@@ -1,0 +1,2 @@
+pub mod nexpose_document;
+pub mod simple_nexpose;

--- a/src/parser/nexpose/nexpose_document.rs
+++ b/src/parser/nexpose/nexpose_document.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+
+use quick_xml::Reader;
+use quick_xml::events::Event;
+
+use crate::error::Error;
+use crate::parser::NessusReport;
+
+/// Determine if the provided XML file has a `NeXposeSimpleXML` root tag.
+pub fn is_nexpose<P: AsRef<Path>>(path: P) -> Result<bool, Error> {
+    let mut reader = Reader::from_file(path)?;
+    reader.trim_text(true);
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf)? {
+            Event::Start(e) => {
+                return Ok(e.name().as_ref() == b"NeXposeSimpleXML");
+            }
+            Event::Eof => return Ok(false),
+            _ => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Parse a Nexpose simple XML file into a [`NessusReport`].
+pub fn parse_file(path: &Path) -> Result<NessusReport, Error> {
+    let mut reader = Reader::from_file(path)?;
+    reader.trim_text(true);
+    let mut buf = Vec::new();
+
+    // Validate root element
+    loop {
+        match reader.read_event_into(&mut buf)? {
+            Event::Start(e) => {
+                if e.name().as_ref() != b"NeXposeSimpleXML" {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "unexpected root element",
+                    )
+                    .into());
+                }
+                break;
+            }
+            Event::Eof => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "unexpected end of file",
+                )
+                .into());
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    super::simple_nexpose::parse(&mut reader)
+}

--- a/src/parser/nexpose/simple_nexpose.rs
+++ b/src/parser/nexpose/simple_nexpose.rs
@@ -1,0 +1,72 @@
+use std::io::BufRead;
+
+use quick_xml::Reader;
+use quick_xml::events::Event;
+
+use crate::error::Error;
+use crate::models::Host;
+use crate::parser::NessusReport;
+
+/// Parse a `NeXposeSimpleXML` document from the provided reader.
+pub fn parse<B: BufRead>(reader: &mut Reader<B>) -> Result<NessusReport, Error> {
+    let mut buf = Vec::new();
+    let mut report = NessusReport::default();
+    report.version = "nexpose-simple-xml".to_string();
+
+    loop {
+        match reader.read_event_into(&mut buf)? {
+            Event::Start(e) => match e.name().as_ref() {
+                b"node" => {
+                    let mut host = empty_host();
+                    for a in e.attributes().flatten() {
+                        match a.key.as_ref() {
+                            b"address" => host.ip = Some(a.unescape_value()?.to_string()),
+                            b"name" => host.name = Some(a.unescape_value()?.to_string()),
+                            _ => {}
+                        }
+                    }
+                    report.hosts.push(host);
+                }
+                _ => {}
+            },
+            Event::End(e) => {
+                if e.name().as_ref() == b"NeXposeSimpleXML" {
+                    break;
+                }
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    // IP fix-up similar to `fix_ips`
+    for host in &mut report.hosts {
+        if host.ip.is_none() {
+            if let Some(name) = host.name.clone() {
+                host.ip = Some(name);
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+fn empty_host() -> Host {
+    Host {
+        id: 0,
+        nessus_report_id: None,
+        name: None,
+        os: None,
+        mac: None,
+        start: None,
+        end: None,
+        ip: None,
+        fqdn: None,
+        netbios: None,
+        notes: None,
+        risk_score: None,
+        user_id: None,
+        engagement_id: None,
+    }
+}


### PR DESCRIPTION
## Summary
- add `nexpose` module with root-tag validation
- stream Nexpose SimpleXML into existing Host and Report models
- dispatch Nexpose XML parsing from `parse_file`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abcab3a29c83208f021ce62affd756