### PR TITLE
Handle additional Nessus host properties and warn on unknown tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "inventory",
+ "lazy_static",
  "libloading 0.7.4",
  "plotters",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rustyline = "13"
 rusqlite = { version = "0.29", features = ["bundled"] }
 rustc_version_runtime = "0.3"
 cargo-lock = "10.1"
+lazy_static = "1.5"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/tests/fixtures/sample.nessus
+++ b/tests/fixtures/sample.nessus
@@ -2,7 +2,17 @@
   <ReportHost name="192.168.0.1">
     <HostProperties>
       <tag name="host-ip">192.168.0.1</tag>
+      <tag name="host-fqdn">example.local</tag>
+      <tag name="netbios-name">EXAMPLE</tag>
       <tag name="operating-system">Linux</tag>
+      <tag name="mac-address">00:11:22:33:44:55</tag>
+      <tag name="HOST_START">Wed Nov 22 19:12:25 2006</tag>
+      <tag name="HOST_END">Wed Nov 22 19:13:25 2006</tag>
+      <tag name="traceroute_hop_0">192.168.0.1</tag>
+      <tag name="traceroute_hop_1">192.168.1.1</tag>
+      <tag name="pcidss:status">passed</tag>
+      <tag name="pcidss:compliant">yes</tag>
+      <tag name="unknown-prop">foo</tag>
       <tag name="MS12-001">KB123456</tag>
     </HostProperties>
     <ReportItem pluginID="100" port="0" svc_name="" protocol="tcp" severity="0" pluginName="Test Plugin">

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,0 +1,57 @@
+use std::fs;
+use std::io::{Result as IoResult, Write};
+use std::sync::{Arc, Mutex};
+
+use risu_rs::parser::parse_file;
+use tracing::Level;
+use tracing_subscriber::fmt;
+
+struct VecWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for VecWriter {
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn parses_traceroute_pcidss_and_logs_unknown() {
+    let sample = fs::canonicalize("tests/fixtures/sample.nessus").unwrap();
+
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let make_writer = {
+        let buf = buf.clone();
+        move || VecWriter(buf.clone())
+    };
+    let subscriber = fmt()
+        .with_max_level(Level::DEBUG)
+        .with_writer(make_writer)
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let report = parse_file(&sample).unwrap();
+
+    let props: Vec<(String, String)> = report
+        .host_properties
+        .iter()
+        .filter_map(|p| {
+            if let (Some(n), Some(v)) = (p.name.clone(), p.value.clone()) {
+                Some((n, v))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(props.iter().any(|(n, _)| n == "traceroute_hop_0"));
+    assert!(props.iter().any(|(n, _)| n == "pcidss:status"));
+
+    let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+    assert!(logs.contains("Unknown XML tags encountered"));
+    assert!(logs.contains("unknown-prop"));
+}


### PR DESCRIPTION
## Summary
- recognize more Nessus host property tags and regex-based patterns
- populate Host fields for known tags and warn on unknown properties
- add tests for traceroute hops, pcidss flags, and unknown tag logging

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abd3433d5883209d8eafe3f251aee0