### PR TITLE
Handle cm namespaced compliance tags

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -295,7 +295,29 @@ fn parse_nessus(path: &Path) -> Result<NessusReport, crate::error::Error> {
                 b"plugin_output" => {
                     current_plugin_output = Some(String::new());
                 }
-                b"description" | b"solution" | b"risk_factor" | b"cvss_base_score" => {
+                b"description"
+                | b"solution"
+                | b"risk_factor"
+                | b"cvss_base_score"
+                | b"cm:compliance-info"
+                | b"cm:compliance-actual-value"
+                | b"cm:compliance-check-id"
+                | b"cm:compliance-policy-value"
+                | b"cm:compliance-audit-file"
+                | b"cm:compliance-check-name"
+                | b"cm:compliance-result"
+                | b"cm:compliance-output"
+                | b"cm:compliance-reference"
+                | b"cm:compliance-see-also"
+                | b"cm:compliance-solution"
+                | b"cm:compliance"
+                | b"cm:root-cause"
+                | b"cm:agent"
+                | b"cm:potential-vulnerability"
+                | b"cm:in-the-news"
+                | b"cm:exploited-by-nessus"
+                | b"cm:unsupported-by-vendor"
+                | b"cm:default-account" => {
                     if current_item_index.is_some() {
                         current_item_tag =
                             Some(String::from_utf8_lossy(e.name().as_ref()).to_string());
@@ -389,6 +411,178 @@ fn parse_nessus(path: &Path) -> Result<NessusReport, crate::error::Error> {
                                         }
                                     }
                                 }
+                                "cm:compliance-info" => {
+                                    item.cm_compliance_info = Some(text.clone());
+                                }
+                                "cm:compliance-actual-value" => {
+                                    item.cm_compliance_actual_value = Some(text.clone());
+                                }
+                                "cm:compliance-check-id" => {
+                                    item.cm_compliance_check_id = Some(text.clone());
+                                }
+                                "cm:compliance-policy-value" => {
+                                    item.cm_compliance_policy_value = Some(text.clone());
+                                }
+                                "cm:compliance-audit-file" => {
+                                    item.cm_compliance_audit_file = Some(text.clone());
+                                }
+                                "cm:compliance-check-name" => {
+                                    item.cm_compliance_check_name = Some(text.clone());
+                                }
+                                "cm:compliance-result" => {
+                                    item.cm_compliance_result = Some(text.clone());
+                                }
+                                "cm:compliance-output" => {
+                                    item.cm_compliance_output = Some(text.clone());
+                                }
+                                "cm:compliance-reference" => {
+                                    item.cm_compliance_reference = Some(text.clone());
+                                }
+                                "cm:compliance-see-also" => {
+                                    item.cm_compliance_see_also = Some(text.clone());
+                                }
+                                "cm:compliance-solution" => {
+                                    item.cm_compliance_solution = Some(text.clone());
+                                }
+                                "cm:compliance" => {
+                                    if let Some(pid) = item.plugin_id {
+                                        if let Some(plugin) = report
+                                            .plugins
+                                            .iter_mut()
+                                            .find(|p| p.plugin_id == Some(pid))
+                                        {
+                                            if plugin.compliance.is_none() {
+                                                plugin.compliance = Some(text.clone());
+                                            }
+                                        }
+                                    }
+                                }
+                                "cm:root-cause" => {
+                                    if let Some(pid) = item.plugin_id {
+                                        if let Some(plugin) = report
+                                            .plugins
+                                            .iter_mut()
+                                            .find(|p| p.plugin_id == Some(pid))
+                                        {
+                                            if plugin.root_cause.is_none() {
+                                                plugin.root_cause = Some(text.clone());
+                                            }
+                                        }
+                                    }
+                                }
+                                "cm:agent" => {
+                                    if let Some(pid) = item.plugin_id {
+                                        if let Some(plugin) = report
+                                            .plugins
+                                            .iter_mut()
+                                            .find(|p| p.plugin_id == Some(pid))
+                                        {
+                                            if plugin.agent.is_none() {
+                                                plugin.agent = Some(text.clone());
+                                            }
+                                        }
+                                    }
+                                }
+                                "cm:potential-vulnerability" => {
+                                    if let Some(pid) = item.plugin_id {
+                                        if let Some(plugin) = report
+                                            .plugins
+                                            .iter_mut()
+                                            .find(|p| p.plugin_id == Some(pid))
+                                        {
+                                            if plugin.potential_vulnerability.is_none() {
+                                                plugin.potential_vulnerability =
+                                                    if text.eq_ignore_ascii_case("true") {
+                                                        Some(true)
+                                                    } else if text.eq_ignore_ascii_case("false") {
+                                                        Some(false)
+                                                    } else {
+                                                        None
+                                                    };
+                                            }
+                                        }
+                                    }
+                                }
+                                "cm:in-the-news" => {
+                                    if let Some(pid) = item.plugin_id {
+                                        if let Some(plugin) = report
+                                            .plugins
+                                            .iter_mut()
+                                            .find(|p| p.plugin_id == Some(pid))
+                                        {
+                                            if plugin.in_the_news.is_none() {
+                                                plugin.in_the_news =
+                                                    if text.eq_ignore_ascii_case("true") {
+                                                        Some(true)
+                                                    } else if text.eq_ignore_ascii_case("false") {
+                                                        Some(false)
+                                                    } else {
+                                                        None
+                                                    };
+                                            }
+                                        }
+                                    }
+                                }
+                                "cm:exploited-by-nessus" => {
+                                    if let Some(pid) = item.plugin_id {
+                                        if let Some(plugin) = report
+                                            .plugins
+                                            .iter_mut()
+                                            .find(|p| p.plugin_id == Some(pid))
+                                        {
+                                            if plugin.exploited_by_nessus.is_none() {
+                                                plugin.exploited_by_nessus =
+                                                    if text.eq_ignore_ascii_case("true") {
+                                                        Some(true)
+                                                    } else if text.eq_ignore_ascii_case("false") {
+                                                        Some(false)
+                                                    } else {
+                                                        None
+                                                    };
+                                            }
+                                        }
+                                    }
+                                }
+                                "cm:unsupported-by-vendor" => {
+                                    if let Some(pid) = item.plugin_id {
+                                        if let Some(plugin) = report
+                                            .plugins
+                                            .iter_mut()
+                                            .find(|p| p.plugin_id == Some(pid))
+                                        {
+                                            if plugin.unsupported_by_vendor.is_none() {
+                                                plugin.unsupported_by_vendor =
+                                                    if text.eq_ignore_ascii_case("true") {
+                                                        Some(true)
+                                                    } else if text.eq_ignore_ascii_case("false") {
+                                                        Some(false)
+                                                    } else {
+                                                        None
+                                                    };
+                                            }
+                                        }
+                                    }
+                                }
+                                "cm:default-account" => {
+                                    if let Some(pid) = item.plugin_id {
+                                        if let Some(plugin) = report
+                                            .plugins
+                                            .iter_mut()
+                                            .find(|p| p.plugin_id == Some(pid))
+                                        {
+                                            if plugin.default_account.is_none() {
+                                                plugin.default_account =
+                                                    if text.eq_ignore_ascii_case("true") {
+                                                        Some(true)
+                                                    } else if text.eq_ignore_ascii_case("false") {
+                                                        Some(false)
+                                                    } else {
+                                                        None
+                                                    };
+                                            }
+                                        }
+                                    }
+                                }
                                 _ => {}
                             }
                         }
@@ -437,6 +631,9 @@ fn parse_nessus(path: &Path) -> Result<NessusReport, crate::error::Error> {
                     current_tag = None;
                 }
                 b"description" | b"solution" | b"risk_factor" | b"cvss_base_score" => {
+                    current_item_tag = None;
+                }
+                name if name.starts_with(b"cm:") => {
                     current_item_tag = None;
                 }
                 b"plugin_output" => {

--- a/tests/fixtures/cm_tags.nessus
+++ b/tests/fixtures/cm_tags.nessus
@@ -1,0 +1,13 @@
+<NessusClientData_v2 xmlns:cm="http://example.com/cm">
+  <ReportHost name="h">
+    <HostProperties></HostProperties>
+    <ReportItem pluginID="1" severity="0" pluginName="plug">
+      <cm:compliance-info>info</cm:compliance-info>
+      <cm:compliance-result>Failed</cm:compliance-result>
+      <cm:root-cause>rc</cm:root-cause>
+      <cm:agent>nessus</cm:agent>
+      <cm:potential-vulnerability>true</cm:potential-vulnerability>
+      <cm:default-account>false</cm:default-account>
+    </ReportItem>
+  </ReportHost>
+</NessusClientData_v2>

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -20,6 +20,26 @@ impl Write for VecWriter {
 }
 
 #[test]
+fn parses_cm_prefixed_tags() {
+    let sample = fs::canonicalize("tests/fixtures/cm_tags.nessus").unwrap();
+    let report = parse_file(&sample).unwrap();
+
+    let item = report.items.first().expect("item");
+    assert_eq!(item.cm_compliance_info.as_deref(), Some("info"));
+    assert_eq!(item.cm_compliance_result.as_deref(), Some("Failed"));
+
+    let plugin = report
+        .plugins
+        .iter()
+        .find(|p| p.plugin_id == Some(1))
+        .unwrap();
+    assert_eq!(plugin.root_cause.as_deref(), Some("rc"));
+    assert_eq!(plugin.agent.as_deref(), Some("nessus"));
+    assert_eq!(plugin.potential_vulnerability, Some(true));
+    assert_eq!(plugin.default_account, Some(false));
+}
+
+#[test]
 fn parses_traceroute_pcidss_and_logs_unknown() {
     let sample = fs::canonicalize("tests/fixtures/sample.nessus").unwrap();
 


### PR DESCRIPTION
## Summary
- parse `cm:` namespaced elements and store on `Item`/`Plugin`
- add test and fixture for `cm:` compliance tags

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68abd7e7059083209d856ce8aa903ca9