### PR TITLE
Log unknown XML elements and host properties separately

### DIFF
--- a/tests/fixtures/sample.nessus
+++ b/tests/fixtures/sample.nessus
@@ -17,5 +17,6 @@
     </HostProperties>
     <ReportItem pluginID="100" port="0" svc_name="" protocol="tcp" severity="0" pluginName="Test Plugin">
     </ReportItem>
+    <unknown-tag></unknown-tag>
   </ReportHost>
 </NessusClientData_v2>

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -72,6 +72,8 @@ fn parses_traceroute_pcidss_and_logs_unknown() {
     assert!(props.iter().any(|(n, _)| n == "pcidss:status"));
 
     let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
-    assert!(logs.contains("Unknown XML tags encountered"));
+    assert!(logs.contains("Unknown XML elements encountered"));
+    assert!(logs.contains("Unknown host properties encountered"));
+    assert!(logs.contains("unknown-tag"));
     assert!(logs.contains("unknown-prop"));
 }


### PR DESCRIPTION
## Summary
- track unknown XML elements and host property names independently during parsing
- log summaries for unknown elements, host properties, and attributes after parsing
- test that unexpected tags and host properties trigger corresponding logs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abdb4aa9ec8320a8fcdc38875327c1