### PR TITLE
Add Nessus parser fixtures for attachments, references, and policy

### DIFF
--- a/tests/fixtures/attachment_ref.nessus
+++ b/tests/fixtures/attachment_ref.nessus
@@ -1,0 +1,10 @@
+<NessusClientData_v2>
+  <ReportHost name="h">
+    <HostProperties></HostProperties>
+    <ReportItem pluginID="1" severity="0" pluginName="plug">
+      <attachment name="a.txt" type="text/plain">aGVsbG8=</attachment>
+      <ref source="CVE">CVE-1234-5678</ref>
+      <xref>CVE-1111-2222</xref>
+    </ReportItem>
+  </ReportHost>
+</NessusClientData_v2>

--- a/tests/fixtures/plugin_metadata.nessus
+++ b/tests/fixtures/plugin_metadata.nessus
@@ -1,0 +1,10 @@
+<NessusClientData_v2>
+  <ReportHost name="h">
+    <HostProperties></HostProperties>
+    <ReportItem pluginID="1" severity="1" pluginName="plug">
+      <description>desc</description>
+      <solution>sol</solution>
+      <risk_factor>Medium</risk_factor>
+    </ReportItem>
+  </ReportHost>
+</NessusClientData_v2>

--- a/tests/fixtures/policy.nessus
+++ b/tests/fixtures/policy.nessus
@@ -1,0 +1,37 @@
+<NessusClientData_v2>
+  <Policy>
+    <policyName>basic</policyName>
+    <policyComments>hello</policyComments>
+    <Preferences>
+      <ServerPreferences>
+        <preference>
+          <name>somepref</name>
+          <value>val</value>
+        </preference>
+      </ServerPreferences>
+      <PluginPreferences>
+        <item>
+          <pluginId>1</pluginId>
+          <fullname>Name</fullname>
+          <preferenceName>pref</preferenceName>
+          <preferenceType>type</preferenceType>
+          <selectedValue>value</selectedValue>
+        </item>
+      </PluginPreferences>
+    </Preferences>
+    <FamilySelection>
+      <FamilyItem>
+        <FamilyName>General</FamilyName>
+        <Status>enabled</Status>
+      </FamilyItem>
+    </FamilySelection>
+    <IndividualPluginSelection>
+      <PluginItem>
+        <PluginID>1</PluginID>
+        <PluginName>plug</PluginName>
+        <PluginFamily>General</PluginFamily>
+        <Status>enabled</Status>
+      </PluginItem>
+    </IndividualPluginSelection>
+  </Policy>
+</NessusClientData_v2>


### PR DESCRIPTION
## Summary
- add fixtures and tests for parsing attachments and reference tags
- test plugin metadata propagation
- exercise policy parsing including preferences and selections

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68abe2fc88308320a8519d4b89d011e7