### PR TITLE
Track rolled-up findings in Nessus items

### DIFF
--- a/migrations/00000000000007_add_rollup_finding/down.sql
+++ b/migrations/00000000000007_add_rollup_finding/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE nessus_items DROP COLUMN rollup_finding;

--- a/migrations/00000000000007_add_rollup_finding/up.sql
+++ b/migrations/00000000000007_add_rollup_finding/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE nessus_items ADD COLUMN rollup_finding BOOLEAN;

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,6 +7,7 @@
 pub mod attachment;
 pub mod family_selection;
 pub mod host_property;
+pub mod item;
 pub mod plugin_metadata;
 pub mod plugin_preference;
 pub mod policy;
@@ -18,6 +19,7 @@ pub mod service_description;
 pub use attachment::Attachment;
 pub use family_selection::FamilySelection;
 pub use host_property::HostProperty;
+pub use item::Item;
 pub use plugin_metadata::NessusPluginMetadata;
 pub use plugin_preference::PluginPreference;
 pub use policy::Policy;
@@ -30,7 +32,7 @@ use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use std::net::IpAddr;
 
-use crate::schema::{nessus_hosts, nessus_items, nessus_patches, nessus_plugins};
+use crate::schema::{nessus_hosts, nessus_patches, nessus_plugins};
 
 #[derive(Debug, Queryable, Identifiable)]
 #[diesel(table_name = nessus_hosts)]
@@ -49,80 +51,6 @@ pub struct Host {
     pub risk_score: Option<i32>,
     pub user_id: Option<i32>,
     pub engagement_id: Option<i32>,
-}
-
-#[derive(Debug, Queryable, Identifiable, Associations)]
-#[diesel(belongs_to(Host, foreign_key = host_id))]
-#[diesel(belongs_to(Plugin, foreign_key = plugin_id))]
-#[diesel(table_name = nessus_items)]
-pub struct Item {
-    pub id: i32,
-    pub host_id: Option<i32>,
-    pub plugin_id: Option<i32>,
-    pub attachment_id: Option<i32>,
-    pub plugin_output: Option<String>,
-    pub port: Option<i32>,
-    pub svc_name: Option<String>,
-    pub protocol: Option<String>,
-    pub severity: Option<i32>,
-    pub plugin_name: Option<String>,
-    pub description: Option<String>,
-    pub solution: Option<String>,
-    pub risk_factor: Option<String>,
-    pub cvss_base_score: Option<f32>,
-    pub verified: Option<bool>,
-    pub cm_compliance_info: Option<String>,
-    pub cm_compliance_actual_value: Option<String>,
-    pub cm_compliance_check_id: Option<String>,
-    pub cm_compliance_policy_value: Option<String>,
-    pub cm_compliance_audit_file: Option<String>,
-    pub cm_compliance_check_name: Option<String>,
-    pub cm_compliance_result: Option<String>,
-    pub cm_compliance_output: Option<String>,
-    pub cm_compliance_reference: Option<String>,
-    pub cm_compliance_see_also: Option<String>,
-    pub cm_compliance_solution: Option<String>,
-    pub real_severity: Option<i32>,
-    pub risk_score: Option<i32>,
-    pub user_id: Option<i32>,
-    pub engagement_id: Option<i32>,
-}
-
-impl Default for Item {
-    fn default() -> Self {
-        Self {
-            id: 0,
-            host_id: None,
-            plugin_id: None,
-            attachment_id: None,
-            plugin_output: None,
-            port: None,
-            svc_name: None,
-            protocol: None,
-            severity: None,
-            plugin_name: None,
-            description: None,
-            solution: None,
-            risk_factor: None,
-            cvss_base_score: None,
-            verified: None,
-            cm_compliance_info: None,
-            cm_compliance_actual_value: None,
-            cm_compliance_check_id: None,
-            cm_compliance_policy_value: None,
-            cm_compliance_audit_file: None,
-            cm_compliance_check_name: None,
-            cm_compliance_result: None,
-            cm_compliance_output: None,
-            cm_compliance_reference: None,
-            cm_compliance_see_also: None,
-            cm_compliance_solution: None,
-            real_severity: None,
-            risk_score: None,
-            user_id: None,
-            engagement_id: None,
-        }
-    }
 }
 
 #[derive(Debug, Queryable, Identifiable)]

--- a/src/models/item.rs
+++ b/src/models/item.rs
@@ -1,0 +1,79 @@
+use diesel::prelude::*;
+
+use crate::schema::nessus_items;
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(super::Host, foreign_key = host_id))]
+#[diesel(belongs_to(super::Plugin, foreign_key = plugin_id))]
+#[diesel(table_name = nessus_items)]
+pub struct Item {
+    pub id: i32,
+    pub host_id: Option<i32>,
+    pub plugin_id: Option<i32>,
+    pub attachment_id: Option<i32>,
+    pub plugin_output: Option<String>,
+    pub port: Option<i32>,
+    pub svc_name: Option<String>,
+    pub protocol: Option<String>,
+    pub severity: Option<i32>,
+    pub plugin_name: Option<String>,
+    pub description: Option<String>,
+    pub solution: Option<String>,
+    pub risk_factor: Option<String>,
+    pub cvss_base_score: Option<f32>,
+    pub verified: Option<bool>,
+    pub cm_compliance_info: Option<String>,
+    pub cm_compliance_actual_value: Option<String>,
+    pub cm_compliance_check_id: Option<String>,
+    pub cm_compliance_policy_value: Option<String>,
+    pub cm_compliance_audit_file: Option<String>,
+    pub cm_compliance_check_name: Option<String>,
+    pub cm_compliance_result: Option<String>,
+    pub cm_compliance_output: Option<String>,
+    pub cm_compliance_reference: Option<String>,
+    pub cm_compliance_see_also: Option<String>,
+    pub cm_compliance_solution: Option<String>,
+    pub real_severity: Option<i32>,
+    pub risk_score: Option<i32>,
+    pub user_id: Option<i32>,
+    pub engagement_id: Option<i32>,
+    pub rollup_finding: Option<bool>,
+}
+
+impl Default for Item {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            host_id: None,
+            plugin_id: None,
+            attachment_id: None,
+            plugin_output: None,
+            port: None,
+            svc_name: None,
+            protocol: None,
+            severity: None,
+            plugin_name: None,
+            description: None,
+            solution: None,
+            risk_factor: None,
+            cvss_base_score: None,
+            verified: None,
+            cm_compliance_info: None,
+            cm_compliance_actual_value: None,
+            cm_compliance_check_id: None,
+            cm_compliance_policy_value: None,
+            cm_compliance_audit_file: None,
+            cm_compliance_check_name: None,
+            cm_compliance_result: None,
+            cm_compliance_output: None,
+            cm_compliance_reference: None,
+            cm_compliance_see_also: None,
+            cm_compliance_solution: None,
+            real_severity: None,
+            risk_score: None,
+            user_id: None,
+            engagement_id: None,
+            rollup_finding: Some(false),
+        }
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,15 +7,15 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use quick_xml::Reader;
 use quick_xml::events::Event;
+use quick_xml::Reader;
 use tracing::{debug, info};
 
 use crate::models::{
     Attachment, FamilySelection, Host, HostProperty, Item, Patch, Plugin, PluginPreference, Policy,
     PolicyPlugin, Reference, ServerPreference, ServiceDescription,
 };
-use base64::{Engine, engine::general_purpose};
+use base64::{engine::general_purpose, Engine};
 use chrono::NaiveDateTime;
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -916,20 +916,16 @@ mod tests {
         assert_eq!(report.patches[0].name.as_deref(), Some("MS12-001"));
         assert_eq!(report.patches[0].value.as_deref(), Some("KB123456"));
         assert_eq!(report.host_properties.len(), 13);
-        assert!(
-            report
-                .host_properties
-                .iter()
-                .any(|p| p.name.as_deref() == Some("host-ip")
-                    && p.value.as_deref() == Some("192.168.0.1"))
-        );
-        assert!(
-            report
-                .host_properties
-                .iter()
-                .any(|p| p.name.as_deref() == Some("operating-system")
-                    && p.value.as_deref() == Some("Linux"))
-        );
+        assert!(report
+            .host_properties
+            .iter()
+            .any(|p| p.name.as_deref() == Some("host-ip")
+                && p.value.as_deref() == Some("192.168.0.1")));
+        assert!(report
+            .host_properties
+            .iter()
+            .any(|p| p.name.as_deref() == Some("operating-system")
+                && p.value.as_deref() == Some("Linux")));
         assert!(report.host_properties.iter().any(
             |p| p.name.as_deref() == Some("MS12-001") && p.value.as_deref() == Some("KB123456")
         ));
@@ -1002,32 +998,24 @@ mod tests {
         std::fs::write(&file_path, xml).unwrap();
         let report = parse_file(&file_path).expect("parse");
         assert_eq!(report.references.len(), 4);
-        assert!(
-            report
-                .references
-                .iter()
-                .any(|r| r.source.as_deref() == Some("CVE")
-                    && r.value.as_deref() == Some("CVE-2023-1111"))
-        );
-        assert!(
-            report
-                .references
-                .iter()
-                .any(|r| r.source.as_deref() == Some("BID")
-                    && r.value.as_deref() == Some("BID-7654"))
-        );
-        assert!(
-            report
-                .references
-                .iter()
-                .any(|r| r.source.as_deref() == Some("CVE")
-                    && r.value.as_deref() == Some("CVE-2023-2222"))
-        );
-        assert!(
-            report.references.iter().any(
-                |r| r.source.as_deref() == Some("OSVDB") && r.value.as_deref() == Some("12345")
-            )
-        );
+        assert!(report
+            .references
+            .iter()
+            .any(|r| r.source.as_deref() == Some("CVE")
+                && r.value.as_deref() == Some("CVE-2023-1111")));
+        assert!(report
+            .references
+            .iter()
+            .any(|r| r.source.as_deref() == Some("BID") && r.value.as_deref() == Some("BID-7654")));
+        assert!(report
+            .references
+            .iter()
+            .any(|r| r.source.as_deref() == Some("CVE")
+                && r.value.as_deref() == Some("CVE-2023-2222")));
+        assert!(report
+            .references
+            .iter()
+            .any(|r| r.source.as_deref() == Some("OSVDB") && r.value.as_deref() == Some("12345")));
     }
 
     #[test]
@@ -1110,6 +1098,7 @@ fn empty_item() -> Item {
         risk_score: None,
         user_id: None,
         engagement_id: None,
+        rollup_finding: Some(false),
     }
 }
 

--- a/src/postprocess/rollups.rs
+++ b/src/postprocess/rollups.rs
@@ -24,6 +24,7 @@ fn run_rollup(
                 }
                 item.real_severity = item.severity;
                 item.severity = Some(-1);
+                item.rollup_finding = Some(true);
             }
         }
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -160,6 +160,7 @@ diesel::table! {
         risk_score -> Nullable<Integer>,
         user_id -> Nullable<Integer>,
         engagement_id -> Nullable<Integer>,
+        rollup_finding -> Nullable<Bool>,
     }
 }
 

--- a/src/templates/pci_compliance.rs
+++ b/src/templates/pci_compliance.rs
@@ -31,6 +31,9 @@ impl Template for PCIComplianceTemplate {
         let mut passed = 0;
         let mut failed = 0;
         for item in &report.items {
+            if item.rollup_finding == Some(true) {
+                continue;
+            }
             if item.plugin_id == Some(33929) {
                 if item
                     .plugin_output

--- a/src/templates/rollup_summary.rs
+++ b/src/templates/rollup_summary.rs
@@ -28,6 +28,9 @@ impl Template for RollupSummaryTemplate {
         let mut print_group = |sev: i32, label: &str| -> Result<(), Box<dyn Error>> {
             let mut unique: BTreeMap<i32, String> = BTreeMap::new();
             for item in &report.items {
+                if item.rollup_finding == Some(true) {
+                    continue;
+                }
                 if item.severity == Some(sev) {
                     if let Some(pid) = item.plugin_id {
                         let name = item.plugin_name.clone().unwrap_or_default();

--- a/src/templates/ssl_medium_str_cipher_support.rs
+++ b/src/templates/ssl_medium_str_cipher_support.rs
@@ -26,6 +26,9 @@ impl Template for SslMediumStrCipherSupportTemplate {
         renderer.text(title)?;
         let mut count = 0;
         for item in &report.items {
+            if item.rollup_finding == Some(true) {
+                continue;
+            }
             if let Some(name) = &item.plugin_name {
                 if name.to_lowercase().contains("ssl medium") {
                     count += 1;

--- a/src/templates/stig_findings_summary.rs
+++ b/src/templates/stig_findings_summary.rs
@@ -28,6 +28,9 @@ impl Template for StigFindingsSummaryTemplate {
         // Summarize counts by severity level.
         let mut counts = [0usize; 5];
         for item in &report.items {
+            if item.rollup_finding == Some(true) {
+                continue;
+            }
             if let Some(sev) = item.severity {
                 if (0..5).contains(&sev) {
                     counts[sev as usize] += 1;


### PR DESCRIPTION
## Summary
- add nullable `rollup_finding` column to `nessus_items`
- track roll-up state in `Item` model and parser
- ignore rolled-up items in rollup processing, queries, and templates

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abe9b67a388320be1eaa9120ff6e76