### PR TITLE
Add helpers for default credential detection

### DIFF
--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -35,6 +35,21 @@ pub trait Template {
         renderer: &mut dyn Renderer,
         args: &HashMap<String, String>,
     ) -> Result<(), Box<dyn Error>>;
+
+    /// Determine if a plugin indicates default credentials.
+    fn has_default_credentials(&self, plugin_id: i32) -> bool {
+        crate::template::helpers::has_default_credentials(plugin_id)
+    }
+
+    /// Produce a warning section for default credential detections.
+    fn default_credentials_section(&self, plugin_ids: &[i32]) -> String {
+        crate::template::helpers::default_credentials_section(plugin_ids)
+    }
+
+    /// Produce an appendix section for default credential detections.
+    fn default_credentials_appendix_section(&self, plugin_ids: &[i32]) -> String {
+        crate::template::helpers::default_credentials_appendix_section(plugin_ids)
+    }
 }
 
 /// Manages discovery and loading of compiled template modules.


### PR DESCRIPTION
## Summary
- flag plugins that accept default credentials
- expose default credential warnings through Template trait
- test default credential detection and appendix generation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68acfd6256c08320be4cd5ed9a94aa9d