### PR TITLE
Add template validation

### DIFF
--- a/tests/template_validation.rs
+++ b/tests/template_validation.rs
@@ -1,0 +1,53 @@
+use risu_rs::parser::NessusReport;
+use risu_rs::renderer::Renderer;
+use risu_rs::template::{Template, TemplateManager};
+use std::collections::HashMap;
+
+struct NoName;
+
+impl Template for NoName {
+    fn name(&self) -> &str {
+        ""
+    }
+
+    fn generate(
+        &self,
+        _report: &NessusReport,
+        _renderer: &mut dyn Renderer,
+        _args: &HashMap<String, String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+}
+
+struct DupTemplate;
+
+impl Template for DupTemplate {
+    fn name(&self) -> &str {
+        "dup"
+    }
+
+    fn generate(
+        &self,
+        _report: &NessusReport,
+        _renderer: &mut dyn Renderer,
+        _args: &HashMap<String, String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+}
+
+#[test]
+fn rejects_template_without_name() {
+    let mut mgr = TemplateManager::new(vec![]);
+    mgr.register(Box::new(NoName));
+    assert!(mgr.available().is_empty());
+}
+
+#[test]
+fn rejects_duplicate_template() {
+    let mut mgr = TemplateManager::new(vec![]);
+    mgr.register(Box::new(DupTemplate));
+    mgr.register(Box::new(DupTemplate));
+    assert_eq!(mgr.available().len(), 1);
+}


### PR DESCRIPTION
## Summary
- validate templates after loading to ensure names exist and are unique
- skip registration of invalid or duplicate templates
- test validation with nameless and duplicate templates

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad002a9d688320ae65471707dd7d3c