### PR TITLE
Add release Makefile with tagging and checksums

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+BINARIES := risu-rs
+TARGET_DIR := target/release
+CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
+.PHONY: build hash tag push publish release
+
+## Build optimized binaries
+build:
+	cargo build --release
+
+## Generate SHA256 and SHA512 hashes for binaries
+hash: build
+	@for bin in $(BINARIES); do sha256sum $(TARGET_DIR)/$$bin > $(TARGET_DIR)/$$bin.sha256; sha512sum $(TARGET_DIR)/$$bin > $(TARGET_DIR)/$$bin.sha512; done
+
+## Create an annotated git tag
+# Usage: make tag VERSION=x.y.z
+tag:
+	@test -n "$(VERSION)" || (echo "Set VERSION=x.y.z" && exit 1)
+	git tag -a v$(VERSION) -m "Release v$(VERSION)"
+
+## Push commits and tags to origin
+# Usage: make push VERSION=x.y.z
+push:
+	@test -n "$(VERSION)" || (echo "Set VERSION=x.y.z" && exit 1)
+	git push origin $(CURRENT_BRANCH)
+	git push origin v$(VERSION)
+
+## Publish the crate to crates.io
+publish:
+	cargo publish
+
+## Run the full release pipeline
+# Usage: make release VERSION=x.y.z [PUBLISH=1]
+release: hash tag push
+	@if [ -n "$(PUBLISH)" ]; then cargo publish; fi

--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ Paths are searched non-recursively and duplicates are ignored.
 Post-processing plugins allow adjusting a parsed report before rendering. They
 implement the [`PostProcess`](src/postprocess/mod.rs) trait and register using
 the `inventory` crate so they are executed in order after parsing.
+
+## Release workflow
+
+Maintainers can use the provided Makefile to cut releases:
+
+- `make build` – compile optimized binaries.
+- `make hash` – build and emit SHA256/SHA512 checksum files alongside binaries.
+- `make tag VERSION=x.y.z` – create an annotated git tag.
+- `make push VERSION=x.y.z` – push commits and tags to `origin`.
+- `make publish` – publish the crate to crates.io.
+- `make release VERSION=x.y.z [PUBLISH=1]` – run build, hashing, tagging and pushing; set `PUBLISH=1` to also publish the crate.


### PR DESCRIPTION
## Summary
- add Makefile with release tasks (build, hash, tag, push, publish)
- document release workflow for maintainers in README

## Testing
- `cargo test`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68ad0f24cec88320a04130fff3eef4f5