### PR TITLE
Add plugin flag fixture and template test

### DIFF
--- a/tests/fixtures/plugin_flags.nessus
+++ b/tests/fixtures/plugin_flags.nessus
@@ -1,0 +1,9 @@
+<NessusClientData_v2 xmlns:cm="http://example.com/cm">
+  <ReportHost name="h">
+    <HostProperties></HostProperties>
+    <ReportItem pluginID="1" severity="0" pluginName="plug">
+      <cm:in-the-news>true</cm:in-the-news>
+      <cm:exploited-by-nessus>true</cm:exploited-by-nessus>
+    </ReportItem>
+  </ReportHost>
+</NessusClientData_v2>

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -136,6 +136,20 @@ fn parses_plugin_metadata_fields() {
 }
 
 #[test]
+fn parses_plugin_flags() {
+    let path = fs::canonicalize("tests/fixtures/plugin_flags.nessus").unwrap();
+    let report = parse_file(&path).unwrap();
+
+    let plugin = report
+        .plugins
+        .iter()
+        .find(|p| p.plugin_id == Some(1))
+        .unwrap();
+    assert_eq!(plugin.in_the_news, Some(true));
+    assert_eq!(plugin.exploited_by_nessus, Some(true));
+}
+
+#[test]
 fn maps_pluginid_zero_to_one() {
     let path = fs::canonicalize("tests/fixtures/plugin_id0.nessus").unwrap();
     let report = parse_file(&path).unwrap();

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -51,3 +51,8 @@ fn ms_update_summary_template_renders() {
 fn graphs_template_renders() {
     run_template("graphs", "OS distribution");
 }
+
+#[test]
+fn pci_compliance_template_renders() {
+    run_template("pci_compliance", "PCI / DSS Compliance Overview");
+}


### PR DESCRIPTION
## Summary
- add plugin_flags.nessus fixture exercising plugin flag parsing
- test parser for in-the-news and exploited-by-nessus flags
- cover pci_compliance template rendering in test suite

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad29cf0d6c832094c43fbf57c02133