### PR TITLE
Add plugin ID whitelist/blacklist filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@ risu-rs --create-config-file       # write default config.yml
 risu-rs migrate --create-tables    # run database migrations
 risu-rs parse scan.nessus -o report.csv -t simple --post-process
 risu-rs parse scan.nessus -o report.pdf -t simple --template-arg title="Custom Title"
+risu-rs parse scan.nessus -o report.csv -t simple --blacklist 19506,34221
+risu-rs parse scan.nessus -o report.pdf -t simple --whitelist 1001,1002
 risu-rs --list-templates           # list available templates
 risu-rs --list-post-process        # list post-process plugins
 ```
+
+Use `--blacklist` or `--whitelist` to control which plugin IDs are included in
+the parsed report. Both options accept comma-separated ID lists. When a
+whitelist is provided, only matching plugin IDs are kept; blacklisted IDs are
+always removed.
 
 ## Configuration
 

--- a/src/postprocess/mod.rs
+++ b/src/postprocess/mod.rs
@@ -4,7 +4,8 @@
 //! [`inventory`] crate. They run sequentially on the [`NessusReport`] after
 //! parsing to adjust or enrich data.
 
-use crate::parser::NessusReport;
+use crate::parser::{filter_report, NessusReport};
+use std::collections::HashSet;
 use tracing::info;
 
 /// Information about a post-processing plugin.
@@ -67,10 +68,17 @@ impl Registry {
     }
 }
 
-/// Convenience helper to run all discovered plugins on a report.
-pub fn process(report: &mut NessusReport) {
+/// Convenience helper to run all discovered plugins on a report, honoring
+/// whitelist/blacklist filters.
+pub fn process(
+    report: &mut NessusReport,
+    whitelist: &HashSet<i32>,
+    blacklist: &HashSet<i32>,
+) {
+    filter_report(report, whitelist, blacklist);
     let registry = Registry::discover();
     registry.run(report);
+    filter_report(report, whitelist, blacklist);
 }
 
 /// Display the names of all registered plugins.

--- a/tests/postprocess.rs
+++ b/tests/postprocess.rs
@@ -1,6 +1,7 @@
 use risu_rs::models::{Host, Item, Plugin};
 use risu_rs::parser::NessusReport;
 use risu_rs::postprocess;
+use std::collections::HashSet;
 
 fn host(name: &str, ip: Option<&str>) -> Host {
     Host {
@@ -27,7 +28,7 @@ fn fix_ips_sets_missing_ip() {
         hosts: vec![host("10.0.0.1", None)],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report);
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
     assert_eq!(report.hosts[0].ip.as_deref(), Some("10.0.0.1"));
 }
 
@@ -40,7 +41,7 @@ fn sort_hosts_orders_by_ip() {
         ],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report);
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
     assert_eq!(report.hosts[0].ip.as_deref(), Some("10.0.0.1"));
     assert_eq!(report.hosts[1].ip.as_deref(), Some("10.0.0.2"));
 }
@@ -53,7 +54,7 @@ fn normalize_plugin_names_sanitizes_strings() {
         plugins: vec![plugin],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report);
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
     assert_eq!(report.plugins[0].plugin_name.as_deref(), Some("Example"));
 }
 
@@ -65,7 +66,7 @@ fn root_cause_sets_known_plugins() {
         plugins: vec![plugin],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report);
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
     assert_eq!(
         report.plugins[0].root_cause.as_deref(),
         Some("Vendor Patch")
@@ -86,7 +87,7 @@ fn risk_score_computes_scores() {
         items: vec![item],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report);
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
     assert_eq!(report.items[0].risk_score, Some(4));
     assert_eq!(report.plugins[0].risk_score, Some(4));
     assert_eq!(report.hosts[0].risk_score, Some(4));
@@ -104,7 +105,7 @@ fn downgrade_plugins_adjusts_severity() {
         items: vec![item1, item2],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report);
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
     assert_eq!(report.items[0].severity, Some(0));
     assert_eq!(report.items[1].severity, Some(2));
 }
@@ -117,7 +118,7 @@ fn adobe_air_rollup_creates_summary_item() {
         items: vec![item],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report);
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
     // original item downgraded
     let orig = report.items.iter().find(|i| i.plugin_id == Some(56959)).unwrap();
     assert_eq!(orig.severity, Some(-1));


### PR DESCRIPTION
## Summary
- add `--blacklist` and `--whitelist` flags to filter plugins by ID
- filter parsed reports and post-processing pipeline using these sets
- document new flags in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad3322f7dc8320bf948837668581b0