### PR TITLE
Add host vulnerability tables and share listings

### DIFF
--- a/src/templates/host_summary.rs
+++ b/src/templates/host_summary.rs
@@ -25,10 +25,55 @@ impl Template for HostSummaryTemplate {
             .unwrap_or("Host Summary Report");
         renderer.text(title)?;
         renderer.text(&format!("Total Hosts: {}", report.hosts.len()))?;
-        for host in &report.hosts {
+        for (idx, host) in report.hosts.iter().enumerate() {
             renderer.text(&host_template_helper::host_heading(host))?;
             renderer.text(&host_template_helper::host_label(host))?;
-            renderer.text(&shares_template_helper::share_enumeration(&[]))?;
+
+            // Gather vulnerability counts for this host.
+            let items: Vec<_> = report
+                .items
+                .iter()
+                .filter(|it| {
+                    it.host_id == Some(idx as i32)
+                        || (it.host_id.is_none() && report.hosts.len() == 1)
+                })
+                .collect();
+            let mut counts = [0u32; 5];
+            for it in items {
+                if let Some(sev) = it.severity {
+                    if (0..=4).contains(&sev) {
+                        counts[sev as usize] += 1;
+                    }
+                }
+            }
+            renderer.text(&format!(
+                "Critical: {}\nHigh: {}\nMedium: {}\nLow: {}\nInfo: {}",
+                counts[4], counts[3], counts[2], counts[1], counts[0]
+            ))?;
+
+            // Enumerate shares for this host from host properties with a `share-` prefix.
+            let mut shares_vec: Vec<(String, String)> = report
+                .host_properties
+                .iter()
+                .filter(|p| p.host_id == Some(idx as i32))
+                .filter_map(|p| {
+                    let name = p.name.as_ref()?;
+                    let value = p.value.as_ref()?;
+                    if name.starts_with("share-") {
+                        Some((
+                            name.trim_start_matches("share-").to_string(),
+                            value.to_string(),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            let shares: Vec<(&str, &str)> = shares_vec
+                .iter()
+                .map(|(n, v)| (n.as_str(), v.as_str()))
+                .collect();
+            renderer.text(&shares_template_helper::share_enumeration(&shares))?;
         }
         Ok(())
     }

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -72,6 +72,40 @@ fn run_template_fixture(name: &str, fixture: &str, expected: &str) {
     assert!(contents.contains(expected));
 }
 
+fn render_template_capture(name: &str) -> String {
+    let tmp = tempdir().unwrap();
+    let sample = fs::canonicalize("tests/fixtures/sample.nessus").unwrap();
+
+    Command::cargo_bin("risu-rs")
+        .unwrap()
+        .args(["--no-banner", "--create-config-file"])
+        .current_dir(&tmp)
+        .assert()
+        .success();
+
+    let output = tmp.path().join("out.csv");
+    Command::cargo_bin("risu-rs")
+        .unwrap()
+        .current_dir(&tmp)
+        .args([
+            "--no-banner",
+            "--config-file",
+            "config.yml",
+            "parse",
+            sample.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "-t",
+            name,
+            "--renderer",
+            "csv",
+        ])
+        .assert()
+        .success();
+
+    fs::read_to_string(output).unwrap()
+}
+
 #[test]
 fn notable_template_renders() {
     run_template("notable", "Notable Findings");
@@ -94,5 +128,17 @@ fn pci_compliance_template_renders() {
 
 #[test]
 fn ssl_summary_template_renders() {
-    run_template_fixture("ssl_summary", "tests/fixtures/ssl.nessus", "Total SSL findings: 2");
+    run_template_fixture(
+        "ssl_summary",
+        "tests/fixtures/ssl.nessus",
+        "Total SSL findings: 2",
+    );
+}
+
+#[test]
+fn host_summary_template_renders() {
+    let contents = render_template_capture("host_summary");
+    assert!(contents.contains("Total Hosts: 1"));
+    assert!(contents.contains("No network shares found."));
+    assert!(contents.contains("Info: 1"));
 }


### PR DESCRIPTION
## Summary
- expand host summary template to count per-host vulnerabilities and enumerate shares from host properties
- add regression test verifying host counts, share section and vulnerability totals

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad41787f40832084f1a7abfcf1f768