### PR TITLE
feat: add exec summary template with authentication and remediation insights

### DIFF
--- a/src/template/scan_helper.rs
+++ b/src/template/scan_helper.rs
@@ -11,6 +11,41 @@ pub fn summary(report: &NessusReport) -> String {
     )
 }
 
+/// Calculate counts of authenticated vs unauthenticated hosts using plugin 19506 output.
+fn authenticated_count(report: &NessusReport) -> (usize, usize) {
+    let mut auth = 0usize;
+    let mut unauth = 0usize;
+    for item in &report.items {
+        if item.plugin_id == Some(19506) {
+            if let Some(ref output) = item.plugin_output {
+                for line in output.lines() {
+                    if let Some((key, value)) = line.split_once(':') {
+                        if key.trim().eq_ignore_ascii_case("credentialed checks") {
+                            if value.to_lowercase().contains("yes") {
+                                auth += 1;
+                            } else {
+                                unauth += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    (auth, unauth)
+}
+
+/// Render an authentication status section.
+pub fn authentication_section(report: &NessusReport) -> String {
+    let (auth, unauth) = authenticated_count(report);
+    format!(
+        "{}\nAuthenticated hosts: {}\nUnauthenticated hosts: {}",
+        helpers::heading2("Authentication Status"),
+        auth,
+        unauth
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -60,5 +95,29 @@ mod tests {
         assert!(s.contains("Hosts: 1"));
         assert!(s.contains("Items: 1"));
         assert!(s.starts_with("## Scan Summary"));
+    }
+
+    #[test]
+    fn authentication_section_counts_hosts() {
+        let mut report = sample_report();
+        report.items = vec![
+            Item {
+                id: 1,
+                host_id: Some(0),
+                plugin_id: Some(19506),
+                plugin_output: Some("Credentialed checks : yes".into()),
+                ..Default::default()
+            },
+            Item {
+                id: 2,
+                host_id: Some(0),
+                plugin_id: Some(19506),
+                plugin_output: Some("Credentialed checks : no".into()),
+                ..Default::default()
+            },
+        ];
+        let section = authentication_section(&report);
+        assert!(section.contains("Authenticated hosts: 1"));
+        assert!(section.contains("Unauthenticated hosts: 1"));
     }
 }

--- a/src/templates/exec_summary.rs
+++ b/src/templates/exec_summary.rs
@@ -3,9 +3,9 @@ use std::error::Error;
 
 use crate::parser::NessusReport;
 use crate::renderer::Renderer;
-use crate::template::{Template, malware_template_helper, scan_helper};
+use crate::template::{helpers, malware_template_helper, scan_helper, Template};
 
-/// Placeholder implementation for the exec_summary template.
+/// Implementation of the exec_summary template providing an overview similar to the Ruby version.
 pub struct ExecSummaryTemplate;
 
 impl Template for ExecSummaryTemplate {
@@ -23,9 +23,91 @@ impl Template for ExecSummaryTemplate {
             .get("title")
             .map(String::as_str)
             .unwrap_or("Exec Summary");
-        renderer.text(title)?;
+        renderer.heading(1, title)?;
+
+        // Scan summary
         renderer.text(&scan_helper::summary(report))?;
-        renderer.text(&malware_template_helper::conficker_section(&[]))?;
+
+        // Severity breakdown
+        let mut severities = [0u32; 5];
+        for item in &report.items {
+            if let Some(sev) = item.severity {
+                if (0..=4).contains(&sev) {
+                    severities[sev as usize] += 1;
+                }
+            }
+        }
+        let severity_text = format!(
+            "{}\nCritical: {}\nHigh: {}\nMedium: {}\nLow: {}\nInfo: {}",
+            helpers::heading2("Severity Breakdown"),
+            severities[4],
+            severities[3],
+            severities[2],
+            severities[1],
+            severities[0]
+        );
+        renderer.text(&severity_text)?;
+
+        // Top hosts by non-informational findings
+        let mut host_counts: HashMap<&str, u32> = HashMap::new();
+        for item in &report.items {
+            if item.severity.unwrap_or(0) > 0 {
+                if let Some(hid) = item.host_id {
+                    if let Some(host) = report.hosts.get(hid as usize) {
+                        if let Some(name) = host.name.as_deref() {
+                            *host_counts.entry(name).or_default() += 1;
+                        }
+                    }
+                }
+            }
+        }
+        let mut host_vec: Vec<(&str, u32)> = host_counts.into_iter().collect();
+        host_vec.sort_by(|a, b| b.1.cmp(&a.1));
+        host_vec.truncate(5);
+        let mut lines = vec![helpers::heading2("Top Hosts")];
+        for (name, count) in host_vec {
+            lines.push(format!("- {name}: {count}"));
+        }
+        renderer.text(&lines.join("\n"))?;
+
+        // Remediation summary – top plugins by count
+        let mut plugin_counts: HashMap<&str, u32> = HashMap::new();
+        for item in &report.items {
+            if item.severity.unwrap_or(0) > 0 {
+                if let Some(pname) = item.plugin_name.as_deref() {
+                    *plugin_counts.entry(pname).or_default() += 1;
+                }
+            }
+        }
+        let mut plugin_vec: Vec<(&str, u32)> = plugin_counts.into_iter().collect();
+        plugin_vec.sort_by(|a, b| b.1.cmp(&a.1));
+        plugin_vec.truncate(5);
+        let mut lines = vec![helpers::heading2("Remediation Summary")];
+        for (name, count) in plugin_vec {
+            lines.push(format!("- {name}: {count}"));
+        }
+        renderer.text(&lines.join("\n"))?;
+
+        // Authentication status
+        renderer.text(&scan_helper::authentication_section(report))?;
+
+        // Conficker section
+        let conficker_hosts: Vec<String> = report
+            .items
+            .iter()
+            .filter(|i| i.plugin_name.as_deref() == Some("Conficker Worm Detection (uncredentialed check)"))
+            .filter_map(|i| {
+                i.host_id.and_then(|hid| {
+                    report
+                        .hosts
+                        .get(hid as usize)
+                        .and_then(|h| h.name.clone())
+                })
+            })
+            .collect();
+        let conf_refs: Vec<&str> = conficker_hosts.iter().map(|s| s.as_str()).collect();
+        renderer.text(&malware_template_helper::conficker_section(&conf_refs))?;
+
         Ok(())
     }
 }

--- a/tests/fixtures/exec_summary_ruby.rb
+++ b/tests/fixtures/exec_summary_ruby.rb
@@ -1,0 +1,71 @@
+require 'rexml/document'
+file = ARGV[0]
+doc = REXML::Document.new(File.read(file))
+
+hosts = doc.elements.to_a('//ReportHost')
+items = doc.elements.to_a('//ReportItem')
+
+severity = Hash.new(0)
+items.each do |ri|
+  s = ri.attributes['severity'].to_i
+  severity[s] += 1
+end
+
+host_counts = Hash.new(0)
+hosts.each do |h|
+  name = h.attributes['name']
+  h.elements.each('ReportItem') do |ri|
+    sev = ri.attributes['severity'].to_i
+    host_counts[name] += 1 if sev > 0
+  end
+end
+top_hosts = host_counts.sort_by { |_,v| -v }[0,5]
+
+plugin_counts = Hash.new(0)
+items.each do |ri|
+  sev = ri.attributes['severity'].to_i
+  next if sev == 0
+  pname = ri.elements['plugin_name']&.text
+  plugin_counts[pname] += 1 if pname
+end
+top_plugins = plugin_counts.sort_by { |_,v| -v }[0,5]
+
+auth = 0; unauth = 0
+hosts.each do |h|
+  h.elements.each('ReportItem[@pluginID="19506"]') do |ri|
+    text = ri.elements['plugin_output']&.text.to_s
+    text.split("\n").each do |line|
+      key,val = line.split(':',2)
+      next unless key && val
+      if key.strip.downcase == 'credentialed checks'
+        if val.downcase.include?('yes')
+          auth += 1
+        else
+          unauth += 1
+        end
+      end
+    end
+  end
+end
+
+conf_hosts = []
+hosts.each do |h|
+  h.elements.each('ReportItem') do |ri|
+    pname = ri.elements['plugin_name']&.text
+    if pname == 'Conficker Worm Detection (uncredentialed check)'
+      conf_hosts << h.attributes['name']
+    end
+  end
+end
+
+puts 'Exec Summary'
+puts "## Scan Summary\nHosts: #{hosts.size}\nItems: #{items.size}"
+puts "## Severity Breakdown\nCritical: #{severity[4]}\nHigh: #{severity[3]}\nMedium: #{severity[2]}\nLow: #{severity[1]}\nInfo: #{severity[0]}"
+puts (["## Top Hosts"] + top_hosts.map { |name, c| "- #{name}: #{c}" }).join("\n")
+puts (["## Remediation Summary"] + top_plugins.map { |name, c| "- #{name}: #{c}" }).join("\n")
+puts "## Authentication Status\nAuthenticated hosts: #{auth}\nUnauthenticated hosts: #{unauth}"
+if conf_hosts.empty?
+  puts 'No Conficker infections detected.'
+else
+  puts (["## Conficker Infections"] + conf_hosts.map { |n| "- #{n}" }).join("\n")
+end


### PR DESCRIPTION
## Summary
- port exec summary reporting logic from Ruby implementation
- include severity breakdowns, top hosts and remediation summaries
- surface authentication status and Conficker malware sections using helpers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad4433cc548320b2f7f84ec5ace21a