### PR TITLE
Add template helper prelude and update templates

### DIFF
--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -24,6 +24,7 @@ pub mod malware_template_helper;
 pub mod scan_helper;
 pub mod shares_template_helper;
 pub mod ssl_template_helper;
+pub mod template_helper;
 
 /// Trait implemented by report templates.
 pub trait Template {

--- a/src/template/template_helper.rs
+++ b/src/template/template_helper.rs
@@ -1,0 +1,92 @@
+//! Common helper functions for report templates.
+//!
+//! This module mirrors helper utilities from the original Ruby implementation
+//! and aggregates the various sub-helpers so templates can import a single
+//! prelude.
+
+// Re-export sub-helper modules for convenience so templates can simply import
+// `template_helper` and access everything under a common namespace.
+pub use super::graph_template_helper as graph;
+pub use super::host_template_helper as host;
+pub use super::malware_template_helper as malware;
+pub use super::scan_helper as scan;
+pub use super::shares_template_helper as shares;
+
+/// Format text as a Markdown heading at the given level.
+///
+/// ```
+/// use risu::template::template_helper::heading;
+/// assert_eq!(heading(2, "Section"), "## Section");
+/// ```
+pub fn heading(level: usize, text: &str) -> String {
+    format!("{} {text}", "#".repeat(level))
+}
+
+/// Render an iterator of items as a Markdown bullet list.
+///
+/// ```
+/// use risu::template::template_helper::bullet_list;
+/// let out = bullet_list(["a", "b"]);
+/// assert_eq!(out, "- a\n- b");
+/// ```
+pub fn bullet_list<I, T>(items: I) -> String
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<str>,
+{
+    items
+        .into_iter()
+        .map(|s| format!("- {}", s.as_ref()))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Format a simple name/value pair.
+///
+/// ```
+/// use risu::template::template_helper::field;
+/// assert_eq!(field("Host", "server"), "Host: server");
+/// ```
+pub fn field(name: &str, value: &str) -> String {
+    format!("{name}: {value}")
+}
+
+/// Generate a simple classification banner appearing above and below text.
+///
+/// ```
+/// use risu::template::template_helper::classification_banner;
+/// let out = classification_banner("UNCLASSIFIED");
+/// assert!(out.contains("UNCLASSIFIED"));
+/// ```
+pub fn classification_banner(text: &str) -> String {
+    let line = format!("*** {text} ***");
+    format!("{line}\n{line}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn heading_levels() {
+        assert_eq!(heading(1, "Title"), "# Title");
+        assert_eq!(heading(2, "Sub"), "## Sub");
+    }
+
+    #[test]
+    fn bullets_work() {
+        let out = bullet_list(["one", "two"]);
+        assert_eq!(out, "- one\n- two");
+    }
+
+    #[test]
+    fn field_format() {
+        assert_eq!(field("A", "B"), "A: B");
+    }
+
+    #[test]
+    fn banner_contains_text() {
+        let b = classification_banner("CLASS");
+        assert!(b.contains("CLASS"));
+    }
+}

--- a/src/templates/exec_summary.rs
+++ b/src/templates/exec_summary.rs
@@ -3,7 +3,10 @@ use std::error::Error;
 
 use crate::parser::NessusReport;
 use crate::renderer::Renderer;
-use crate::template::{helpers, malware_template_helper, scan_helper, Template};
+use crate::template::{
+    template_helper::{self, malware, scan},
+    Template,
+};
 
 /// Implementation of the exec_summary template providing an overview similar to the Ruby version.
 pub struct ExecSummaryTemplate;
@@ -26,7 +29,7 @@ impl Template for ExecSummaryTemplate {
         renderer.heading(1, title)?;
 
         // Scan summary
-        renderer.text(&scan_helper::summary(report))?;
+        renderer.text(&scan::summary(report))?;
 
         // Severity breakdown
         let mut severities = [0u32; 5];
@@ -37,14 +40,18 @@ impl Template for ExecSummaryTemplate {
                 }
             }
         }
+        let severity_fields = [
+            template_helper::field("Critical", &severities[4].to_string()),
+            template_helper::field("High", &severities[3].to_string()),
+            template_helper::field("Medium", &severities[2].to_string()),
+            template_helper::field("Low", &severities[1].to_string()),
+            template_helper::field("Info", &severities[0].to_string()),
+        ]
+        .join("\n");
         let severity_text = format!(
-            "{}\nCritical: {}\nHigh: {}\nMedium: {}\nLow: {}\nInfo: {}",
-            helpers::heading2("Severity Breakdown"),
-            severities[4],
-            severities[3],
-            severities[2],
-            severities[1],
-            severities[0]
+            "{}\n{}",
+            template_helper::heading(2, "Severity Breakdown"),
+            severity_fields
         );
         renderer.text(&severity_text)?;
 
@@ -64,11 +71,16 @@ impl Template for ExecSummaryTemplate {
         let mut host_vec: Vec<(&str, u32)> = host_counts.into_iter().collect();
         host_vec.sort_by(|a, b| b.1.cmp(&a.1));
         host_vec.truncate(5);
-        let mut lines = vec![helpers::heading2("Top Hosts")];
-        for (name, count) in host_vec {
-            lines.push(format!("- {name}: {count}"));
-        }
-        renderer.text(&lines.join("\n"))?;
+        let host_lines: Vec<String> = host_vec
+            .into_iter()
+            .map(|(name, count)| format!("{name}: {count}"))
+            .collect();
+        let host_section = format!(
+            "{}\n{}",
+            template_helper::heading(2, "Top Hosts"),
+            template_helper::bullet_list(&host_lines)
+        );
+        renderer.text(&host_section)?;
 
         // Remediation summary – top plugins by count
         let mut plugin_counts: HashMap<&str, u32> = HashMap::new();
@@ -82,31 +94,34 @@ impl Template for ExecSummaryTemplate {
         let mut plugin_vec: Vec<(&str, u32)> = plugin_counts.into_iter().collect();
         plugin_vec.sort_by(|a, b| b.1.cmp(&a.1));
         plugin_vec.truncate(5);
-        let mut lines = vec![helpers::heading2("Remediation Summary")];
-        for (name, count) in plugin_vec {
-            lines.push(format!("- {name}: {count}"));
-        }
-        renderer.text(&lines.join("\n"))?;
+        let plugin_lines: Vec<String> = plugin_vec
+            .into_iter()
+            .map(|(name, count)| format!("{name}: {count}"))
+            .collect();
+        let plugin_section = format!(
+            "{}\n{}",
+            template_helper::heading(2, "Remediation Summary"),
+            template_helper::bullet_list(&plugin_lines)
+        );
+        renderer.text(&plugin_section)?;
 
         // Authentication status
-        renderer.text(&scan_helper::authentication_section(report))?;
+        renderer.text(&scan::authentication_section(report))?;
 
         // Conficker section
         let conficker_hosts: Vec<String> = report
             .items
             .iter()
-            .filter(|i| i.plugin_name.as_deref() == Some("Conficker Worm Detection (uncredentialed check)"))
+            .filter(|i| {
+                i.plugin_name.as_deref() == Some("Conficker Worm Detection (uncredentialed check)")
+            })
             .filter_map(|i| {
-                i.host_id.and_then(|hid| {
-                    report
-                        .hosts
-                        .get(hid as usize)
-                        .and_then(|h| h.name.clone())
-                })
+                i.host_id
+                    .and_then(|hid| report.hosts.get(hid as usize).and_then(|h| h.name.clone()))
             })
             .collect();
         let conf_refs: Vec<&str> = conficker_hosts.iter().map(|s| s.as_str()).collect();
-        renderer.text(&malware_template_helper::conficker_section(&conf_refs))?;
+        renderer.text(&malware::conficker_section(&conf_refs))?;
 
         Ok(())
     }

--- a/src/templates/graphs.rs
+++ b/src/templates/graphs.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 use crate::parser::NessusReport;
 use crate::renderer::Renderer;
-use crate::template::{Template, graph_template_helper};
+use crate::template::{template_helper::graph, Template};
 
 /// Placeholder implementation for the graphs template.
 pub struct GraphsTemplate;
@@ -22,11 +22,11 @@ impl Template for GraphsTemplate {
         let title = args.get("title").map(String::as_str).unwrap_or("Graphs");
         renderer.heading(1, title)?;
         let tmp = std::env::temp_dir();
-        if let Ok(uri) = graph_template_helper::os_distribution_data_uri(report, &tmp) {
+        if let Ok(uri) = graph::os_distribution_data_uri(report, &tmp) {
             renderer.heading(2, "OS distribution (Windows 2000/XP variants combined)")?;
             renderer.text(&uri)?;
         }
-        if let Ok(uri) = graph_template_helper::top_vuln_data_uri(report, &tmp, 5) {
+        if let Ok(uri) = graph::top_vuln_data_uri(report, &tmp, 5) {
             renderer.heading(2, "Top vulnerabilities")?;
             renderer.text(&uri)?;
         }


### PR DESCRIPTION
## Summary
- add `template_helper` module with Markdown heading, bullet list, field and classification banner helpers
- re-export host, malware, graph, shares and scan helper modules for easy template access
- switch existing templates to the new helpers for cleaner output

## Testing
- `cargo test` *(fails: command didn't complete within time)*

------
https://chatgpt.com/codex/tasks/task_e_68ada0db78388320aa55332300b23da9