### PR TITLE
Add assets template with host details

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -240,6 +240,7 @@ fn run() -> Result<(), error::Error> {
         let mut manager = template::TemplateManager::new(paths);
         manager.register(Box::new(template::SimpleTemplate));
         manager.register(Box::new(templates::TemplateTemplate));
+        manager.register(Box::new(templates::AssetsTemplate));
         manager.register(Box::new(templates::HostSummaryTemplate));
         manager.register(Box::new(templates::MSPatchSummaryTemplate));
         manager.register(Box::new(templates::PCIComplianceTemplate));
@@ -293,6 +294,7 @@ fn run() -> Result<(), error::Error> {
             let mut manager = template::TemplateManager::new(paths);
             manager.register(Box::new(template::SimpleTemplate));
             manager.register(Box::new(templates::TemplateTemplate));
+            manager.register(Box::new(templates::AssetsTemplate));
             manager.register(Box::new(templates::HostSummaryTemplate));
             manager.register(Box::new(templates::MSPatchSummaryTemplate));
             manager.register(Box::new(templates::PCIComplianceTemplate));

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -25,6 +25,7 @@ pub mod template;
 pub mod top_25;
 
 pub use authentication_summary::AuthenticationSummaryTemplate;
+pub use assets::AssetsTemplate;
 pub use cover_sheet::CoverSheetTemplate;
 pub use exec_summary::ExecSummaryTemplate;
 pub use executive_summary_detailed::ExecutiveSummaryDetailedTemplate;

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -246,3 +246,14 @@ fn host_findings_csv_template_renders() {
         "Critical Plugin",
     );
 }
+
+#[test]
+fn assets_template_renders_host_details() {
+    let contents = render_template_capture("assets");
+    assert!(contents.contains("Name: 192.168.0.1"));
+    assert!(contents.contains("FQDN: example.local"));
+    assert!(contents.contains("IP: 192.168.0.1"));
+    assert!(contents.contains("NetBIOS: EXAMPLE"));
+    assert!(contents.contains("MAC: 00:11:22:33:44:55"));
+    assert!(contents.contains("OS: Linux"));
+}


### PR DESCRIPTION
## Summary
- port `assets` template to Rust and expose host details (name, FQDN, IP, NetBIOS, MAC, OS)
- register `AssetsTemplate` alongside other templates and wire it into CLI
- cover template with fixture-based test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68adb18b72188320b3a8dfd4115c1f93