### PR TITLE
Parse scan info and expose authentication helpers

### DIFF
--- a/src/template/template_helper.rs
+++ b/src/template/template_helper.rs
@@ -11,6 +11,8 @@ pub use super::host_template_helper as host;
 pub use super::malware_template_helper as malware;
 pub use super::scan_helper as scan;
 pub use super::shares_template_helper as shares;
+#[allow(unused_imports)]
+pub use super::scan_helper::{authenticated_count, scan_info_to_hash};
 
 /// Format text as a Markdown heading at the given level.
 ///


### PR DESCRIPTION
## Summary
- parse plugin 19506 output into key/value pairs
- count authenticated vs unauthenticated hosts
- expose scan helpers to templates and test classification logic

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68adb5b6c9d483209b638ff7761e12ad