### PR TITLE
feat: expand template search and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ or expose a `create_template` constructor in a dynamic library. The
 `TemplateManager` searches for dynamic libraries in the following locations,
 in order:
 
-1. A `templates/` directory next to the executable.
+1. The built-in `src/templates` directory shipped with the project.
 2. The current working directory.
 3. `$HOME/.risu/templates`.
 4. Any additional paths listed in the configuration `template_paths`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,8 @@ struct Cli {
     /// List available post-processing plugins
     #[arg(long = "list-post-process")]
     list_post_process: bool,
-    /// List available templates
+    /// List available templates. Templates are searched in built-in
+    /// `src/templates`, the current working directory, and `$HOME/.risu/templates`.
     #[arg(long = "list-templates")]
     list_templates: bool,
     /// Comma-separated plugin IDs to blacklist
@@ -93,7 +94,8 @@ enum Commands {
     Parse {
         /// File to parse
         file: std::path::PathBuf,
-        /// Template to use for rendering
+        /// Template to use for rendering. Templates are searched in
+        /// `src/templates`, the current directory, and `$HOME/.risu/templates`.
         #[arg(short, long, default_value = "simple")]
         template: String,
         /// Output file for generated document

--- a/src/template/manager.rs
+++ b/src/template/manager.rs
@@ -1,0 +1,143 @@
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+    fs,
+    path::PathBuf,
+};
+
+use libloading::{Library, Symbol};
+
+use super::Template;
+
+/// Manages discovery and loading of compiled template modules.
+pub struct TemplateManager {
+    templates: HashMap<String, Box<dyn Template>>,
+    _libs: Vec<Library>,
+    paths: Vec<PathBuf>,
+}
+
+impl TemplateManager {
+    /// Create a new manager that searches the provided paths along with
+    /// default locations.
+    pub fn new(paths: Vec<PathBuf>) -> Self {
+        let mut search_paths = Vec::new();
+
+        // 1. Built-in templates shipped with the source tree (src/templates).
+        let built_in = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("templates");
+        search_paths.push(built_in);
+
+        // 2. The current working directory (non-recursive).
+        if let Ok(cwd) = std::env::current_dir() {
+            search_paths.push(cwd);
+        }
+
+        // 3. User-specific template directory ($HOME/.risu/templates).
+        if let Some(home) = std::env::var_os("HOME") {
+            search_paths.push(PathBuf::from(home).join(".risu").join("templates"));
+        }
+
+        // Append any additional provided paths.
+        search_paths.extend(paths);
+
+        // Deduplicate paths while preserving order.
+        let mut seen = HashSet::new();
+        search_paths.retain(|p| seen.insert(p.clone()));
+
+        Self {
+            templates: HashMap::new(),
+            _libs: Vec::new(),
+            paths: search_paths,
+        }
+    }
+
+    fn validate(&self, tmpl: &dyn Template) -> Result<(), String> {
+        let name = tmpl.name();
+        if name.trim().is_empty() {
+            return Err("template name cannot be empty".into());
+        }
+        if self.templates.contains_key(name) {
+            return Err(format!("template '{}' already registered", name));
+        }
+        Ok(())
+    }
+
+    /// Load templates from all configured paths. Each dynamic library is
+    /// expected to expose a `create_template` function returning
+    /// `Box<dyn Template>`.
+    pub fn load_templates(&mut self) -> Result<(), Box<dyn Error>> {
+        for path in &self.paths {
+            if let Ok(entries) = fs::read_dir(path) {
+                for entry in entries.flatten() {
+                    let p = entry.path();
+                    if p.extension().and_then(|s| s.to_str()) == Some("so") {
+                        unsafe {
+                            match Library::new(&p) {
+                                Ok(lib) => {
+                                    let ctor = lib.get::<Symbol<unsafe fn() -> Box<dyn Template>>>(
+                                        b"create_template",
+                                    );
+                                    match ctor {
+                                        Ok(ctor) => {
+                                            let tmpl = ctor();
+                                            if let Err(e) = self.validate(tmpl.as_ref()) {
+                                                eprintln!(
+                                                    "invalid template module '{}': {}",
+                                                    p.display(),
+                                                    e
+                                                );
+                                            } else {
+                                                let name = tmpl.name().to_string();
+                                                self.templates.insert(name, tmpl);
+                                                self._libs.push(lib);
+                                            }
+                                        }
+                                        Err(e) => {
+                                            eprintln!(
+                                                "invalid template module '{}': {}",
+                                                p.display(),
+                                                e
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    eprintln!("failed to load template '{}': {}", p.display(), e);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Register a template instance manually.
+    pub fn register(&mut self, tmpl: Box<dyn Template>) {
+        if let Err(e) = self.validate(tmpl.as_ref()) {
+            eprintln!("invalid template '{}': {}", tmpl.name(), e);
+        } else {
+            let name = tmpl.name().to_string();
+            self.templates.insert(name, tmpl);
+        }
+    }
+
+    /// Retrieve a template by name.
+    pub fn get(&self, name: &str) -> Option<&Box<dyn Template>> {
+        self.templates.get(name)
+    }
+
+    /// List available template names.
+    pub fn available(&self) -> Vec<String> {
+        self.templates.keys().cloned().collect()
+    }
+
+    /// Display all available template names.
+    pub fn display(&self) {
+        for name in self.available() {
+            println!("{}", name);
+        }
+    }
+}

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -5,14 +5,8 @@
 //! the configured template paths. The [`TemplateManager`] handles discovery and
 //! selection of templates.
 
-use std::{
-    collections::{HashMap, HashSet},
-    error::Error,
-    fs,
-    path::PathBuf,
-};
-
-use libloading::{Library, Symbol};
+use std::collections::HashMap;
+use std::error::Error;
 
 use crate::{graphs, parser::NessusReport, renderer::Renderer};
 
@@ -26,6 +20,9 @@ pub mod shares_template_helper;
 pub mod ssl_template_helper;
 pub mod template_helper;
 pub mod templater;
+pub mod manager;
+
+pub use manager::TemplateManager;
 
 /// Trait implemented by report templates.
 pub trait Template {
@@ -52,139 +49,6 @@ pub trait Template {
     /// Produce an appendix section for default credential detections.
     fn default_credentials_appendix_section(&self, plugin_ids: &[i32]) -> String {
         crate::template::helpers::default_credentials_appendix_section(plugin_ids)
-    }
-}
-
-/// Manages discovery and loading of compiled template modules.
-pub struct TemplateManager {
-    templates: HashMap<String, Box<dyn Template>>,
-    _libs: Vec<Library>,
-    paths: Vec<PathBuf>,
-}
-
-impl TemplateManager {
-    /// Create a new manager that searches the provided paths along with
-    /// default locations.
-    pub fn new(paths: Vec<PathBuf>) -> Self {
-        let mut search_paths = Vec::new();
-
-        // 1. Templates bundled with the executable.
-        if let Ok(mut exe_path) = std::env::current_exe() {
-            exe_path.pop();
-            search_paths.push(exe_path.join("templates"));
-        }
-
-        // 2. The current working directory.
-        if let Ok(cwd) = std::env::current_dir() {
-            search_paths.push(cwd);
-        }
-
-        // 3. User-specific template directory ($HOME/.risu/templates).
-        if let Some(home) = std::env::var_os("HOME") {
-            search_paths.push(PathBuf::from(home).join(".risu").join("templates"));
-        }
-
-        // Append any additional provided paths.
-        search_paths.extend(paths);
-
-        // Deduplicate paths while preserving order.
-        let mut seen = HashSet::new();
-        search_paths.retain(|p| seen.insert(p.clone()));
-
-        Self {
-            templates: HashMap::new(),
-            _libs: Vec::new(),
-            paths: search_paths,
-        }
-    }
-
-    fn validate(&self, tmpl: &dyn Template) -> Result<(), String> {
-        let name = tmpl.name();
-        if name.trim().is_empty() {
-            return Err("template name cannot be empty".into());
-        }
-        if self.templates.contains_key(name) {
-            return Err(format!("template '{}' already registered", name));
-        }
-        Ok(())
-    }
-
-    /// Load templates from all configured paths. Each dynamic library is
-    /// expected to expose a `create_template` function returning
-    /// `Box<dyn Template>`.
-    pub fn load_templates(&mut self) -> Result<(), Box<dyn Error>> {
-        for path in &self.paths {
-            if let Ok(entries) = fs::read_dir(path) {
-                for entry in entries.flatten() {
-                    let p = entry.path();
-                    if p.extension().and_then(|s| s.to_str()) == Some("so") {
-                        unsafe {
-                            match Library::new(&p) {
-                                Ok(lib) => {
-                                    let ctor = lib.get::<Symbol<unsafe fn() -> Box<dyn Template>>>(
-                                        b"create_template",
-                                    );
-                                    match ctor {
-                                        Ok(ctor) => {
-                                            let tmpl = ctor();
-                                            if let Err(e) = self.validate(tmpl.as_ref()) {
-                                                eprintln!(
-                                                    "invalid template module '{}': {}",
-                                                    p.display(),
-                                                    e
-                                                );
-                                            } else {
-                                                let name = tmpl.name().to_string();
-                                                self.templates.insert(name, tmpl);
-                                                self._libs.push(lib);
-                                            }
-                                        }
-                                        Err(e) => {
-                                            eprintln!(
-                                                "invalid template module '{}': {}",
-                                                p.display(),
-                                                e
-                                            );
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    eprintln!("failed to load template '{}': {}", p.display(), e);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Register a template instance manually.
-    pub fn register(&mut self, tmpl: Box<dyn Template>) {
-        if let Err(e) = self.validate(tmpl.as_ref()) {
-            eprintln!("invalid template '{}': {}", tmpl.name(), e);
-        } else {
-            let name = tmpl.name().to_string();
-            self.templates.insert(name, tmpl);
-        }
-    }
-
-    /// Retrieve a template by name.
-    pub fn get(&self, name: &str) -> Option<&Box<dyn Template>> {
-        self.templates.get(name)
-    }
-
-    /// List available template names.
-    pub fn available(&self) -> Vec<String> {
-        self.templates.keys().cloned().collect()
-    }
-
-    /// Display all available template names.
-    pub fn display(&self) {
-        for name in self.available() {
-            println!("{}", name);
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- discover templates in built-in `src/templates`, current directory, and `$HOME/.risu/templates`
- deduplicate template paths and validate modules before registration
- document template search locations in CLI help and README

## Testing
- `cargo test` *(fails: compilation didn't complete due to environment timeouts)*
- `cargo check` *(fails: compilation didn't complete due to environment timeouts)*


------
https://chatgpt.com/codex/tasks/task_e_68adb9655a248320b2b07b4793666f51