### PR TITLE
Add report metadata model and CLI configuration

### DIFF
--- a/migrations/00000000000010_create_reports/down.sql
+++ b/migrations/00000000000010_create_reports/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE nessus_policies DROP COLUMN nessus_report_id;
+DROP TABLE nessus_reports;

--- a/migrations/00000000000010_create_reports/up.sql
+++ b/migrations/00000000000010_create_reports/up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE nessus_reports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    author TEXT,
+    company TEXT,
+    classification TEXT,
+    user_id INTEGER,
+    engagement_id INTEGER
+);
+
+ALTER TABLE nessus_policies ADD COLUMN nessus_report_id INTEGER;

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,18 @@ pub struct Config {
     /// Paths to search for compiled template modules.
     #[serde(default = "default_template_paths")]
     pub template_paths: Vec<String>,
+    /// Report title metadata
+    #[serde(default)]
+    pub report_title: Option<String>,
+    /// Report author metadata
+    #[serde(default)]
+    pub report_author: Option<String>,
+    /// Report company metadata
+    #[serde(default)]
+    pub report_company: Option<String>,
+    /// Report classification metadata
+    #[serde(default)]
+    pub report_classification: Option<String>,
 }
 
 impl Default for Config {
@@ -36,6 +48,10 @@ impl Default for Config {
             log_level: default_log_level(),
             log_format: default_log_format(),
             template_paths: default_template_paths(),
+            report_title: None,
+            report_author: None,
+            report_company: None,
+            report_classification: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,18 @@ enum Commands {
         /// Template-specific arguments as `key=value` pairs
         #[arg(long = "template-arg", value_name = "key=value", value_parser = parse_key_val::<String, String>)]
         template_args: Vec<(String, String)>,
+        /// Report title metadata
+        #[arg(long = "report-title")]
+        report_title: Option<String>,
+        /// Report author metadata
+        #[arg(long = "report-author")]
+        report_author: Option<String>,
+        /// Report company metadata
+        #[arg(long = "report-company")]
+        report_company: Option<String>,
+        /// Report classification metadata
+        #[arg(long = "report-classification")]
+        report_classification: Option<String>,
     },
     /// Index NASL plugins and store metadata
     PluginIndex {
@@ -279,6 +291,10 @@ fn run() -> Result<(), error::Error> {
             post_process,
             renderer: renderer_opt,
             template_args,
+            report_title,
+            report_author,
+            report_company,
+            report_classification,
         }) => {
             let blacklist: HashSet<i32> = cli.blacklist.iter().cloned().collect();
             let whitelist: HashSet<i32> = cli.whitelist.iter().cloned().collect();
@@ -287,6 +303,13 @@ fn run() -> Result<(), error::Error> {
             if post_process {
                 postprocess::process(&mut report, &whitelist, &blacklist);
             }
+
+            // Populate report metadata from CLI or configuration
+            report.report.title = report_title.or(cfg.report_title.clone());
+            report.report.author = report_author.or(cfg.report_author.clone());
+            report.report.company = report_company.or(cfg.report_company.clone());
+            report.report.classification =
+                report_classification.or(cfg.report_classification.clone());
 
             let paths = cfg
                 .template_paths

--- a/src/models.rs
+++ b/src/models.rs
@@ -13,6 +13,7 @@ pub mod plugin_preference;
 pub mod policy;
 pub mod policy_plugin;
 pub mod reference;
+pub mod report;
 pub mod server_preference;
 pub mod service_description;
 pub mod version;
@@ -26,6 +27,7 @@ pub use plugin_preference::PluginPreference;
 pub use policy::Policy;
 pub use policy_plugin::PolicyPlugin;
 pub use reference::Reference;
+pub use report::Report;
 pub use server_preference::ServerPreference;
 pub use service_description::ServiceDescription;
 
@@ -35,7 +37,8 @@ use std::net::IpAddr;
 
 use crate::schema::{nessus_hosts, nessus_patches, nessus_plugins};
 
-#[derive(Debug, Queryable, Identifiable)]
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Report, foreign_key = nessus_report_id))]
 #[diesel(table_name = nessus_hosts)]
 pub struct Host {
     pub id: i32,

--- a/src/models/policy.rs
+++ b/src/models/policy.rs
@@ -1,17 +1,25 @@
 use diesel::prelude::*;
 
+use crate::models::Report;
 use crate::schema::nessus_policies;
 
-#[derive(Debug, Queryable, Identifiable)]
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Report, foreign_key = nessus_report_id))]
 #[diesel(table_name = nessus_policies)]
 pub struct Policy {
     pub id: i32,
+    pub nessus_report_id: Option<i32>,
     pub name: Option<String>,
     pub comments: Option<String>,
 }
 
 impl Default for Policy {
     fn default() -> Self {
-        Self { id: 0, name: None, comments: None }
+        Self {
+            id: 0,
+            nessus_report_id: None,
+            name: None,
+            comments: None,
+        }
     }
 }

--- a/src/models/report.rs
+++ b/src/models/report.rs
@@ -1,0 +1,42 @@
+use diesel::prelude::*;
+
+use crate::models::Host;
+use crate::schema::nessus_reports;
+
+#[derive(Debug, Queryable, Identifiable)]
+#[diesel(table_name = nessus_reports)]
+pub struct Report {
+    pub id: i32,
+    pub title: Option<String>,
+    pub author: Option<String>,
+    pub company: Option<String>,
+    pub classification: Option<String>,
+    pub user_id: Option<i32>,
+    pub engagement_id: Option<i32>,
+}
+
+impl Report {
+    /// Returns the earliest start time across all hosts in the report.
+    pub fn scan_date(&self, hosts: &[Host]) -> Option<chrono::NaiveDateTime> {
+        hosts.iter().filter_map(|h| h.start).min()
+    }
+
+    /// Static text describing Nessus severity ratings.
+    pub fn scanner_nessus_ratings_text(&self) -> &'static str {
+        "Nessus severity ratings: 0 (Info), 1 (Low), 2 (Medium), 3 (High), 4 (Critical)."
+    }
+}
+
+impl Default for Report {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            title: None,
+            author: None,
+            company: None,
+            classification: None,
+            user_id: None,
+            engagement_id: None,
+        }
+    }
+}

--- a/src/parser/simple_nexpose.rs
+++ b/src/parser/simple_nexpose.rs
@@ -5,7 +5,7 @@ use csv::Reader;
 use serde::Deserialize;
 
 use crate::error::Error;
-use crate::models::{Host, Item, Plugin, ServiceDescription};
+use crate::models::{Host, Item, Plugin, Report, ServiceDescription};
 
 /// Parsed representation of a simplified Nexpose CSV export.
 #[derive(Default)]
@@ -69,6 +69,7 @@ pub fn parse_file(path: &Path) -> Result<SimpleNexpose, Error> {
 impl From<SimpleNexpose> for super::NessusReport {
     fn from(s: SimpleNexpose) -> Self {
         super::NessusReport {
+            report: Report::default(),
             version: "nexpose-simple".to_string(),
             hosts: s.hosts,
             items: s.items,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,16 @@
 diesel::table! {
+    nessus_reports (id) {
+        id -> Integer,
+        title -> Nullable<Text>,
+        author -> Nullable<Text>,
+        company -> Nullable<Text>,
+        classification -> Nullable<Text>,
+        user_id -> Nullable<Integer>,
+        engagement_id -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
     versions (id) {
         id -> Integer,
         version -> Text,
@@ -27,6 +39,7 @@ diesel::table! {
 diesel::table! {
     nessus_policies (id) {
         id -> Integer,
+        nessus_report_id -> Nullable<Integer>,
         name -> Nullable<Text>,
         comments -> Nullable<Text>,
     }
@@ -231,6 +244,7 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+    nessus_reports,
     versions,
     nessus_hosts,
     nessus_host_properties,

--- a/src/template/graph_template_helper.rs
+++ b/src/template/graph_template_helper.rs
@@ -31,11 +31,12 @@ pub fn top_vuln_data_uri(
 mod tests {
     use super::*;
     use crate::graphs::count_os;
-    use crate::models::{Host, Item};
+    use crate::models::{Host, Item, Report};
     use tempfile::tempdir;
 
     fn report() -> NessusReport {
         NessusReport {
+            report: Report::default(),
             version: "1".into(),
             hosts: vec![
                 Host {

--- a/src/template/scan_helper.rs
+++ b/src/template/scan_helper.rs
@@ -56,10 +56,11 @@ pub fn authentication_section(report: &NessusReport) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Host, Item};
+    use crate::models::{Host, Item, Report};
 
     fn sample_report() -> NessusReport {
         NessusReport {
+            report: Report::default(),
             version: "1".into(),
             hosts: vec![Host {
                 id: 1,


### PR DESCRIPTION
## Summary
- add `Report` model to store report metadata and helper methods
- expose CLI and config fields for report title, author, company, and classification
- wire metadata into parsed reports and database schema

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68adcec5406083209dd85b5996d9f480