### PR TITLE
Add console_here script for local DB console

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ Maintainers can use the provided Makefile to cut releases:
 - `make clean` – remove build artifacts.
 - `make test` – run tests against all supported database backends (`make test-sqlite`, `make test-postgres`, `make test-mysql` to run individually).
 - `make notify VERSION=x.y.z WEBHOOK=https://example.com/hook` – send a release announcement to a webhook (e.g. Slack).
+
+## Developer utilities
+
+- `scripts/generate_rollups.py` – regenerate rollup plugin definitions from the legacy Ruby project.
+- `scripts/console_here` – open an interactive database console using the `config.yml` in the current directory:
+   ```bash
+   ./scripts/console_here
+   ```

--- a/scripts/console_here
+++ b/scripts/console_here
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the risu-rs database console using configuration from the current directory.
+
+# Location of repository root relative to this script
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Directory where the script was invoked
+CALLER_DIR="$PWD"
+
+CONFIG_PATH="$CALLER_DIR/config.yml"
+if [ -f "$CONFIG_PATH" ]; then
+    CONFIG_ARG=(--config-file "$CONFIG_PATH")
+else
+    CONFIG_ARG=()
+fi
+
+cd "$REPO_ROOT"
+cargo run --quiet -- --console "${CONFIG_ARG[@]}"


### PR DESCRIPTION
## Summary
- add `scripts/console_here` to launch the interactive database console using the current directory's config
- document developer utilities including the new console helper

## Testing
- `DATABASE_URL=sqlite://:memory: cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68add8dc3384832095fe75f4c45ef551