### PR TITLE
Handle invalid scan documents gracefully

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     Regex(#[from] regex::Error),
     #[error(transparent)]
     Yaml(#[from] serde_yaml::Error),
+    #[error("invalid document: {0}")]
+    InvalidDocument(String),
     #[error("migration error: {0}")]
     Migration(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("template error: {0}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,14 @@ where
 
 fn main() {
     if let Err(e) = run() {
-        error!("{e}");
+        match e {
+            error::Error::InvalidDocument(msg) => {
+                eprintln!("Failed to parse document: {msg}");
+            }
+            other => {
+                error!("{other}");
+            }
+        }
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
## Summary
- add `Error::InvalidDocument` for malformed or unsupported scan files
- validate XML root in `parser::parse_file` and report unsupported roots
- show clear CLI message on invalid input and add regression tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68addcc1f81483209984ec84f5f5ec2f