### PR TITLE
feat: add host and plugin filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1713,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "inventory",
+ "ipnet",
  "lazy_static",
  "libloading 0.7.4",
  "plotters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rusqlite = { version = "0.29", features = ["bundled"] }
 rustc_version_runtime = "0.3"
 cargo-lock = "10.1"
 lazy_static = "1.5"
+ipnet = "2.9"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/parser/simple_nexpose.rs
+++ b/src/parser/simple_nexpose.rs
@@ -84,6 +84,7 @@ impl From<SimpleNexpose> for super::NessusReport {
             family_selections: Vec::new(),
             plugin_preferences: Vec::new(),
             server_preferences: Vec::new(),
+            filters: super::Filters::default(),
         }
     }
 }

--- a/src/postprocess/mod.rs
+++ b/src/postprocess/mod.rs
@@ -4,7 +4,7 @@
 //! [`inventory`] crate. They run sequentially on the [`NessusReport`] after
 //! parsing to adjust or enrich data.
 
-use crate::parser::{filter_report, NessusReport};
+use crate::parser::{filter_report, Filters, NessusReport};
 use std::collections::HashSet;
 use tracing::info;
 
@@ -74,11 +74,12 @@ pub fn process(
     report: &mut NessusReport,
     whitelist: &HashSet<i32>,
     blacklist: &HashSet<i32>,
+    filters: &Filters,
 ) {
-    filter_report(report, whitelist, blacklist);
+    filter_report(report, whitelist, blacklist, filters);
     let registry = Registry::discover();
     registry.run(report);
-    filter_report(report, whitelist, blacklist);
+    filter_report(report, whitelist, blacklist, filters);
 }
 
 /// Display the names of all registered plugins.

--- a/src/template/graph_template_helper.rs
+++ b/src/template/graph_template_helper.rs
@@ -120,6 +120,7 @@ mod tests {
             family_selections: Vec::new(),
             plugin_preferences: Vec::new(),
             server_preferences: Vec::new(),
+            filters: Default::default(),
         }
     }
 

--- a/tests/postprocess.rs
+++ b/tests/postprocess.rs
@@ -1,5 +1,5 @@
 use risu_rs::models::{Host, Item, Plugin};
-use risu_rs::parser::NessusReport;
+use risu_rs::parser::{Filters, NessusReport};
 use risu_rs::postprocess;
 use std::collections::HashSet;
 
@@ -28,7 +28,7 @@ fn fix_ips_sets_missing_ip() {
         hosts: vec![host("10.0.0.1", None)],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
     assert_eq!(report.hosts[0].ip.as_deref(), Some("10.0.0.1"));
 }
 
@@ -41,7 +41,7 @@ fn sort_hosts_orders_by_ip() {
         ],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
     assert_eq!(report.hosts[0].ip.as_deref(), Some("10.0.0.1"));
     assert_eq!(report.hosts[1].ip.as_deref(), Some("10.0.0.2"));
 }
@@ -54,7 +54,7 @@ fn normalize_plugin_names_sanitizes_strings() {
         plugins: vec![plugin],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
     assert_eq!(report.plugins[0].plugin_name.as_deref(), Some("Example"));
 }
 
@@ -66,7 +66,7 @@ fn root_cause_sets_known_plugins() {
         plugins: vec![plugin],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
     assert_eq!(
         report.plugins[0].root_cause.as_deref(),
         Some("Vendor Patch")
@@ -87,7 +87,7 @@ fn risk_score_computes_scores() {
         items: vec![item],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
     assert_eq!(report.items[0].risk_score, Some(4));
     assert_eq!(report.plugins[0].risk_score, Some(4));
     assert_eq!(report.hosts[0].risk_score, Some(4));
@@ -105,7 +105,7 @@ fn downgrade_plugins_adjusts_severity() {
         items: vec![item1, item2],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
     assert_eq!(report.items[0].severity, Some(0));
     assert_eq!(report.items[1].severity, Some(2));
 }
@@ -118,7 +118,7 @@ fn adobe_air_rollup_creates_summary_item() {
         items: vec![item],
         ..NessusReport::default()
     };
-    postprocess::process(&mut report, &HashSet::new(), &HashSet::new());
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
     // original item downgraded
     let orig = report.items.iter().find(|i| i.plugin_id == Some(56959)).unwrap();
     assert_eq!(orig.severity, Some(-1));


### PR DESCRIPTION
## Summary
- extend CLI to filter by host IP, MAC, host ID, and plugin ID
- filter hosts and items in parser using new criteria and track applied filters
- expose filter summary to templates via helper

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68adfd90ec7c8320a2702793a56c6372