### PR TITLE
Add plugin output search CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ risu-rs parse scan.nessus -o report.csv -t simple --blacklist 19506,34221
 risu-rs parse scan.nessus -o report.pdf -t simple --whitelist 1001,1002
 risu-rs --list-templates           # list available templates
 risu-rs --list-post-process        # list post-process plugins
+risu-rs --search-output keyword    # find keyword in plugin output
 ```
 
 Use `--blacklist` or `--whitelist` to control which plugin IDs are included in
 the parsed report. Both options accept comma-separated ID lists. When a
 whitelist is provided, only matching plugin IDs are kept; blacklisted IDs are
 always removed.
+
+The `--search-output` option performs a case-insensitive search of the
+`plugin_output` column and prints matching host IP and plugin name pairs.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- add search_plugin_output helper on Item for LIKE queries
- expose new `--search-output` flag to find host/plugin pairs by plugin output
- document search-output feature

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae148ac2a08320873b1c715b508680