### PR TITLE
Implement authentication summary and top 25 templates

### DIFF
--- a/src/templates/authentication_summary.rs
+++ b/src/templates/authentication_summary.rs
@@ -3,9 +3,9 @@ use std::error::Error;
 
 use crate::parser::NessusReport;
 use crate::renderer::Renderer;
-use crate::template::Template;
+use crate::template::{template_helper, Template};
 
-/// Placeholder implementation for the authentication_summary template.
+/// Report summarizing counts of authenticated vs unauthenticated hosts.
 pub struct AuthenticationSummaryTemplate;
 
 impl Template for AuthenticationSummaryTemplate {
@@ -23,8 +23,16 @@ impl Template for AuthenticationSummaryTemplate {
             .get("title")
             .map(String::as_str)
             .unwrap_or("Authentication Summary");
-        renderer.text(title)?;
-        renderer.text(&format!("Hosts: {}", report.hosts.len()))?;
+        renderer.heading(1, title)?;
+
+        // Count hosts that were authenticated versus those that were not.
+        let (auth, unauth) = template_helper::authenticated_count(report);
+        let lines = [
+            template_helper::field("Authenticated hosts", &auth.to_string()),
+            template_helper::field("Unauthenticated hosts", &unauth.to_string()),
+        ]
+        .join("\n");
+        renderer.text(&lines)?;
         Ok(())
     }
 }

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -187,6 +187,20 @@ fn graphs_template_creates_and_embeds_graphs() {
 }
 
 #[test]
+fn authentication_summary_reports_counts() {
+    let output = render_template_capture_raw("authentication_summary");
+    assert!(output.contains("Authenticated hosts: 0"));
+    assert!(output.contains("Unauthenticated hosts: 0"));
+}
+
+#[test]
+fn top_25_template_lists_plugins() {
+    let output = render_template_capture_raw("top_25");
+    assert!(output.contains("Top Plugins"));
+    assert!(output.contains("Test Plugin (100): 1"));
+}
+
+#[test]
 fn pci_compliance_template_renders() {
     run_template("pci_compliance", "PCI / DSS Compliance Overview");
 }


### PR DESCRIPTION
## Summary
- implement AuthenticationSummary template with real host counts
- implement Top25 template listing most common plugins
- test templates for authentication and top 25 output

## Testing
- `cargo test`
- `cargo run -- --list-templates 2>/dev/null | grep -E 'authentication_summary|top_25'`


------
https://chatgpt.com/codex/tasks/task_e_68ae23fb87908320877c4b677aa92e30