### PR TITLE
Add report prefix and template settings configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,17 @@ database_url: sqlite://:memory:
 log_level: info
 template_paths:
   - ./templates
+# Prefix added to report output paths
+report_prefix: reports/
+# Per-template default arguments keyed by template name
+template_settings:
+  simple:
+    title: "Example Report"
 ```
+
+`report_prefix` prepends a directory to generated report paths. The
+`template_settings` map supplies default template arguments; values provided on
+the command line with `--template-arg` override these defaults.
 
 ## Template API
 


### PR DESCRIPTION
## Summary
- support optional `report_prefix` for output paths
- allow configuring per-template default arguments with `template_settings`
- document new config options

## Testing
- `cargo fmt`
- `cargo -Znext-lockfile-bump test` *(fails: package `diesel_migrations v2.2.0` requires rustc 1.78.0 or newer)*

------
https://chatgpt.com/codex/tasks/task_e_68ae62b57c048320a84bdd31b0efeeb4