### PR TITLE
Add Nessus XML generator and fixtures

### DIFF
--- a/tests/fixtures/multi_host.nessus
+++ b/tests/fixtures/multi_host.nessus
@@ -1,0 +1,12 @@
+<NessusClientData_v2>
+  <ReportHost name="h1">
+    <HostProperties></HostProperties>
+    <ReportItem pluginID="1" severity="0" pluginName="plug1"></ReportItem>
+    <ReportItem pluginID="2" severity="0" pluginName="plug2"></ReportItem>
+  </ReportHost>
+  <ReportHost name="h2">
+    <HostProperties></HostProperties>
+    <ReportItem pluginID="1" severity="0" pluginName="plug1"></ReportItem>
+    <ReportItem pluginID="2" severity="0" pluginName="plug2"></ReportItem>
+  </ReportHost>
+</NessusClientData_v2>

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -161,6 +161,23 @@ fn maps_pluginid_zero_to_one() {
 }
 
 #[test]
+fn parses_multiple_hosts_and_plugins() {
+    let path = fs::canonicalize("tests/fixtures/multi_host.nessus").unwrap();
+    let report = parse_file(&path).unwrap();
+
+    assert_eq!(report.hosts.len(), 2);
+    assert_eq!(report.items.len(), 4);
+
+    let ids: std::collections::HashSet<i32> = report
+        .items
+        .iter()
+        .filter_map(|i| i.plugin_id)
+        .collect();
+    assert!(ids.contains(&1));
+    assert!(ids.contains(&2));
+}
+
+#[test]
 fn parses_policy_block() {
     let path = fs::canonicalize("tests/fixtures/policy.nessus").unwrap();
     let report = parse_file(&path).unwrap();

--- a/tools/nessus_generator.rs
+++ b/tools/nessus_generator.rs
@@ -1,0 +1,25 @@
+use std::env;
+use std::io::{self, Write};
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let host_count: usize = args
+        .next()
+        .expect("host count")
+        .parse()
+        .expect("host count should be a number");
+    let plugin_ids: Vec<String> = args.collect();
+
+    let mut out = io::BufWriter::new(io::stdout());
+    writeln!(out, "<NessusClientData_v2>").unwrap();
+    for i in 0..host_count {
+        writeln!(out, "  <ReportHost name=\"h{}\">", i + 1).unwrap();
+        writeln!(out, "    <HostProperties></HostProperties>").unwrap();
+        for pid in &plugin_ids {
+            writeln!(out, "    <ReportItem pluginID=\"{}\" severity=\"0\" pluginName=\"plug{}\"></ReportItem>", pid, pid).unwrap();
+        }
+        writeln!(out, "  </ReportHost>").unwrap();
+    }
+    writeln!(out, "</NessusClientData_v2>").unwrap();
+}
+


### PR DESCRIPTION
## Summary
- add a small tool to generate minimal Nessus XML from host count and plugin IDs
- generate a multi-host fixture using the tool for parser regression
- test parser on the new fixture

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae7491036083209f3d6485cf000035