### PR TITLE
Add plugin severity override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ report_prefix: reports/
 template_settings:
   simple:
     title: "Example Report"
+# Override plugin severities keyed by plugin ID
+severity_overrides:
+  41028: 0
 ```
 
 `report_prefix` prepends a directory to generated report paths. The
 `template_settings` map supplies default template arguments; values provided on
-the command line with `--template-arg` override these defaults.
+the command line with `--template-arg` override these defaults. The
+`severity_overrides` map adjusts item severities after parsing, allowing
+specific plugin IDs to be downgraded or upgraded.
 
 ## Template API
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,9 @@
 //! template_settings:
 //!   simple:
 //!     title: Example Report
+//! # Override plugin severities keyed by plugin ID
+//! severity_overrides:
+//!   41028: 0
 //! ```
 
 use serde::{Deserialize, Serialize};
@@ -51,6 +54,9 @@ pub struct Config {
     /// Default argument values passed to templates keyed by template name
     #[serde(default)]
     pub template_settings: HashMap<String, HashMap<String, String>>,
+    /// Override plugin severities keyed by plugin ID
+    #[serde(default)]
+    pub severity_overrides: HashMap<i32, i32>,
 }
 
 impl Default for Config {
@@ -66,6 +72,7 @@ impl Default for Config {
             report_classification: None,
             report_prefix: None,
             template_settings: HashMap::new(),
+            severity_overrides: HashMap::new(),
         }
     }
 }
@@ -106,6 +113,10 @@ pub fn create_config(path: &Path) -> Result<(), crate::error::Error> {
             output
                 .push_str("# Default argument values passed to templates keyed by template name\n");
             output.push_str("# template_settings:\n#   simple:\n#     title: Example Report\n");
+        }
+        if line.starts_with("severity_overrides:") {
+            output.push_str("# Override plugin severities keyed by plugin ID\n");
+            output.push_str("# severity_overrides:\n#   41028: 0\n");
         }
         output.push_str(line);
         output.push('\n');

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,6 +389,7 @@ fn run() -> Result<(), error::Error> {
             let blacklist: HashSet<i32> = cli.blacklist.iter().cloned().collect();
             let whitelist: HashSet<i32> = cli.whitelist.iter().cloned().collect();
             let mut report = parser::parse_file(&file)?;
+            parser::apply_severity_overrides(&mut report, &cfg.severity_overrides);
             let filters = parser::Filters {
                 host_ip,
                 host_mac,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,7 +9,7 @@ mod saint;
 mod security_center;
 mod simple_nexpose;
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
@@ -423,6 +423,20 @@ pub fn filter_report(
     report
         .policy_plugins
         .retain(|p| p.plugin_id.map_or(true, |pid| allowed_pids.contains(&pid)));
+}
+
+/// Override item severities based on provided plugin mappings.
+pub fn apply_severity_overrides(report: &mut NessusReport, overrides: &HashMap<i32, i32>) {
+    if overrides.is_empty() {
+        return;
+    }
+    for item in &mut report.items {
+        if let Some(pid) = item.plugin_id {
+            if let Some(&sev) = overrides.get(&pid) {
+                item.severity = Some(sev);
+            }
+        }
+    }
 }
 
 /// Validate and parse a Nessus XML file into ORM models.

--- a/tests/severity_overrides.rs
+++ b/tests/severity_overrides.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+
+use risu_rs::models::Item;
+use risu_rs::parser::{apply_severity_overrides, NessusReport};
+
+#[test]
+fn overrides_update_item_severity() {
+    let mut item = Item::default();
+    item.plugin_id = Some(1234);
+    item.severity = Some(4);
+    let mut report = NessusReport {
+        items: vec![item],
+        ..NessusReport::default()
+    };
+    let mut overrides = HashMap::new();
+    overrides.insert(1234, 1);
+    apply_severity_overrides(&mut report, &overrides);
+    assert_eq!(report.items[0].severity, Some(1));
+}


### PR DESCRIPTION
## Summary
- allow per-plugin severity overrides via `severity_overrides` config
- apply severity overrides to parsed report items
- document configuration and add tests

## Testing
- `DATABASE_URL=sqlite://:memory: cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae77778ed08320a65df764a5efbc35