### PR TITLE
Add scanner tracking across models and parsers

### DIFF
--- a/migrations/00000000000011_add_scanner/down.sql
+++ b/migrations/00000000000011_add_scanner/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE nessus_plugins DROP COLUMN scanner_id;
+ALTER TABLE nessus_items DROP COLUMN scanner_id;
+ALTER TABLE nessus_hosts DROP COLUMN scanner_id;
+DROP TABLE scanners;

--- a/migrations/00000000000011_add_scanner/up.sql
+++ b/migrations/00000000000011_add_scanner/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE scanners (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    scanner_type TEXT NOT NULL,
+    scanner_version TEXT
+);
+
+ALTER TABLE nessus_hosts ADD COLUMN scanner_id INTEGER REFERENCES scanners(id);
+ALTER TABLE nessus_items ADD COLUMN scanner_id INTEGER REFERENCES scanners(id);
+ALTER TABLE nessus_plugins ADD COLUMN scanner_id INTEGER REFERENCES scanners(id);

--- a/src/console.rs
+++ b/src/console.rs
@@ -24,7 +24,7 @@ pub fn run(config_path: &Path) -> Result<(), error::Error> {
                     break;
                 }
                 if input.eq_ignore_ascii_case("hosts") {
-                    match models::Host::ip_list(&mut dconn) {
+                    match models::Host::ip_list(&mut dconn, None) {
                         Ok(list) => println!("{list}"),
                         Err(e) => println!("{e}"),
                     }

--- a/src/graphs/malware.rs
+++ b/src/graphs/malware.rs
@@ -56,7 +56,7 @@ pub fn malware(report: &NessusReport, dir: &Path) -> Result<PathBuf, Box<dyn Err
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Host, Item, Report};
+    use crate::models::{Host, Item, Report, Scanner};
     use tempfile::tempdir;
 
     fn report() -> NessusReport {
@@ -79,6 +79,7 @@ mod tests {
                     risk_score: None,
                     user_id: None,
                     engagement_id: None,
+                    scanner_id: None,
                 },
                 Host {
                     id: 1,
@@ -95,6 +96,7 @@ mod tests {
                     risk_score: None,
                     user_id: None,
                     engagement_id: None,
+                    scanner_id: None,
                 },
             ],
             items: vec![Item { id: 1, host_id: Some(0), plugin_id: Some(34221), ..Item::default() }],
@@ -110,6 +112,7 @@ mod tests {
             plugin_preferences: Vec::new(),
             server_preferences: Vec::new(),
             filters: Default::default(),
+            scanner: Scanner::default(),
         }
     }
 

--- a/src/graphs/mod.rs
+++ b/src/graphs/mod.rs
@@ -84,6 +84,7 @@ mod tests {
             risk_score: None,
             user_id: None,
             engagement_id: None,
+            scanner_id: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,7 +327,7 @@ fn run() -> Result<(), error::Error> {
         use crate::schema::nessus_hosts::dsl::{ip, nessus_hosts};
 
         let mut conn = SqliteConnection::establish(&cfg.database_url)?;
-        let items = models::Item::search_plugin_output(&mut conn, keyword)?;
+        let items = models::Item::search_plugin_output(&mut conn, keyword, None)?;
         for item in items {
             let host = item
                 .host_id

--- a/src/models/host.rs
+++ b/src/models/host.rs
@@ -72,6 +72,7 @@ mod tests {
             risk_score: None,
             user_id: None,
             engagement_id: None,
+            scanner_id: None,
         }
     }
 
@@ -108,6 +109,7 @@ mod tests {
             user_id: None,
             engagement_id: None,
             rollup_finding: Some(false),
+            scanner_id: None,
         }
     }
 

--- a/src/models/scanner.rs
+++ b/src/models/scanner.rs
@@ -1,0 +1,28 @@
+use diesel::prelude::*;
+
+use crate::schema::scanners;
+
+#[derive(Debug, Queryable, Identifiable)]
+#[diesel(table_name = scanners)]
+pub struct Scanner {
+    pub id: i32,
+    pub scanner_type: String,
+    pub scanner_version: Option<String>,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = scanners)]
+pub struct NewScanner<'a> {
+    pub scanner_type: &'a str,
+    pub scanner_version: Option<&'a str>,
+}
+
+impl Default for Scanner {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            scanner_type: String::new(),
+            scanner_version: None,
+        }
+    }
+}

--- a/src/parser/nexpose/simple_nexpose.rs
+++ b/src/parser/nexpose/simple_nexpose.rs
@@ -49,6 +49,7 @@ pub fn parse<B: BufRead>(reader: &mut Reader<B>) -> Result<NessusReport, Error> 
         }
     }
 
+    report.set_scanner("Nexpose", None);
     Ok(report)
 }
 
@@ -68,5 +69,6 @@ fn empty_host() -> Host {
         risk_score: None,
         user_id: None,
         engagement_id: None,
+        scanner_id: None,
     }
 }

--- a/src/parser/nmap.rs
+++ b/src/parser/nmap.rs
@@ -114,6 +114,7 @@ pub fn parse_file(path: &Path) -> Result<NessusReport, Error> {
         buf.clear();
     }
 
+    report.set_scanner("Nmap", None);
     Ok(report)
 }
 
@@ -133,5 +134,6 @@ fn empty_host() -> Host {
         risk_score: None,
         user_id: None,
         engagement_id: None,
+        scanner_id: None,
     }
 }

--- a/src/parser/openvas.rs
+++ b/src/parser/openvas.rs
@@ -7,5 +7,5 @@ use super::NessusReport;
 /// Parse an OpenVAS report. OpenVAS exports are generally compatible with the
 /// Nessus XML schema, so we simply reuse the existing Nessus parser.
 pub fn parse_file(path: &Path) -> Result<NessusReport, Error> {
-    super::parse_nessus(path)
+    super::parse_nessus(path, "OpenVAS")
 }

--- a/src/parser/qualys.rs
+++ b/src/parser/qualys.rs
@@ -7,5 +7,5 @@ use super::NessusReport;
 /// Parse a Qualys export. Qualys can produce Nessus compatible XML, so we
 /// delegate to the shared Nessus parser.
 pub fn parse_file(path: &Path) -> Result<NessusReport, Error> {
-    super::parse_nessus(path)
+    super::parse_nessus(path, "Qualys")
 }

--- a/src/parser/saint.rs
+++ b/src/parser/saint.rs
@@ -7,5 +7,5 @@ use super::NessusReport;
 /// Parse a SAINT export. These reports use the Nessus XML schema so the
 /// generic Nessus parser is sufficient.
 pub fn parse_file(path: &Path) -> Result<NessusReport, Error> {
-    super::parse_nessus(path)
+    super::parse_nessus(path, "SAINT")
 }

--- a/src/parser/security_center.rs
+++ b/src/parser/security_center.rs
@@ -7,5 +7,5 @@ use super::NessusReport;
 /// Parse a Tenable SecurityCenter export. SecurityCenter uses the Nessus XML
 /// format so the standard Nessus parser can handle these reports.
 pub fn parse_file(path: &Path) -> Result<NessusReport, Error> {
-    super::parse_nessus(path)
+    super::parse_nessus(path, "SecurityCenter")
 }

--- a/src/parser/simple_nexpose.rs
+++ b/src/parser/simple_nexpose.rs
@@ -5,7 +5,7 @@ use csv::Reader;
 use serde::Deserialize;
 
 use crate::error::Error;
-use crate::models::{Host, Item, Plugin, Report, ServiceDescription};
+use crate::models::{Host, Item, Plugin, Report, Scanner, ServiceDescription};
 
 /// Parsed representation of a simplified Nexpose CSV export.
 #[derive(Default)]
@@ -68,7 +68,7 @@ pub fn parse_file(path: &Path) -> Result<SimpleNexpose, Error> {
 
 impl From<SimpleNexpose> for super::NessusReport {
     fn from(s: SimpleNexpose) -> Self {
-        super::NessusReport {
+        let mut r = super::NessusReport {
             report: Report::default(),
             version: "nexpose-simple".to_string(),
             hosts: s.hosts,
@@ -84,8 +84,11 @@ impl From<SimpleNexpose> for super::NessusReport {
             family_selections: Vec::new(),
             plugin_preferences: Vec::new(),
             server_preferences: Vec::new(),
+            scanner: Scanner::default(),
             filters: super::Filters::default(),
-        }
+        };
+        r.set_scanner("Nexpose", None);
+        r
     }
 }
 
@@ -105,6 +108,7 @@ fn empty_host() -> Host {
         risk_score: None,
         user_id: None,
         engagement_id: None,
+        scanner_id: None,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,6 +33,7 @@ diesel::table! {
         risk_score -> Nullable<Integer>,
         user_id -> Nullable<Integer>,
         engagement_id -> Nullable<Integer>,
+        scanner_id -> Nullable<Integer>,
     }
 }
 
@@ -145,6 +146,7 @@ diesel::table! {
         user_id -> Nullable<Integer>,
         engagement_id -> Nullable<Integer>,
         policy_id -> Nullable<Integer>,
+        scanner_id -> Nullable<Integer>,
     }
 }
 
@@ -181,6 +183,15 @@ diesel::table! {
         user_id -> Nullable<Integer>,
         engagement_id -> Nullable<Integer>,
         rollup_finding -> Nullable<Bool>,
+        scanner_id -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
+    scanners (id) {
+        id -> Integer,
+        scanner_type -> Text,
+        scanner_version -> Nullable<Text>,
     }
 }
 
@@ -260,4 +271,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     nessus_family_selections,
     nessus_plugin_preferences,
     nessus_server_preferences,
+    scanners,
 );

--- a/src/template/graph_template_helper.rs
+++ b/src/template/graph_template_helper.rs
@@ -41,7 +41,7 @@ pub fn malware_data_uri(
 mod tests {
     use super::*;
     use crate::graphs::count_os;
-    use crate::models::{Host, Item, Report};
+    use crate::models::{Host, Item, Report, Scanner};
     use tempfile::tempdir;
 
     fn report() -> NessusReport {
@@ -64,6 +64,7 @@ mod tests {
                     risk_score: None,
                     user_id: None,
                     engagement_id: None,
+                    scanner_id: None,
                 },
                 Host {
                     id: 2,
@@ -80,6 +81,7 @@ mod tests {
                     risk_score: None,
                     user_id: None,
                     engagement_id: None,
+                    scanner_id: None,
                 },
                 Host {
                     id: 3,
@@ -96,6 +98,7 @@ mod tests {
                     risk_score: None,
                     user_id: None,
                     engagement_id: None,
+                    scanner_id: None,
                 },
                 Host {
                     id: 4,
@@ -112,6 +115,7 @@ mod tests {
                     risk_score: None,
                     user_id: None,
                     engagement_id: None,
+                    scanner_id: None,
                 },
             ],
             items: vec![Item {
@@ -133,6 +137,7 @@ mod tests {
             plugin_preferences: Vec::new(),
             server_preferences: Vec::new(),
             filters: Default::default(),
+            scanner: Scanner::default(),
         }
     }
 

--- a/src/template/helpers.rs
+++ b/src/template/helpers.rs
@@ -43,7 +43,7 @@ pub fn embed_graph(bytes: &[u8]) -> Result<String, Box<dyn Error>> {
 /// Generate the top vulnerabilities graph and return it as a data URI.
 pub fn top_vuln_graph(conn: &mut SqliteConnection) -> Result<String, Box<dyn Error>> {
     let dir: PathBuf = std::env::temp_dir();
-    let path = TopVulnGraph::generate(conn, &dir, 10)?;
+        let path = TopVulnGraph::generate(conn, &dir, 10, None)?;
     let bytes = fs::read(path)?;
     embed_graph(&bytes)
 }
@@ -318,6 +318,7 @@ mod tests {
             risk_score: None,
             user_id: None,
             engagement_id: None,
+            scanner_id: None,
         };
 
         let item = Item {
@@ -352,6 +353,7 @@ mod tests {
             user_id: None,
             engagement_id: None,
             rollup_finding: Some(false),
+            scanner_id: None,
         };
 
         assert!(has_unsupported_software(&host, &[item]));
@@ -388,6 +390,7 @@ mod tests {
             user_id: None,
             engagement_id: None,
             rollup_finding: Some(false),
+            scanner_id: None,
         };
         assert!(!has_unsupported_software(&host, &[clean]));
     }
@@ -462,6 +465,7 @@ mod tests {
     #[diesel(table_name = nessus_hosts)]
     struct NewHost<'a> {
         ip: Option<&'a str>,
+        scanner_id: Option<i32>,
     }
 
     #[derive(Insertable)]
@@ -548,6 +552,7 @@ mod tests {
         diesel::insert_into(nessus_hosts::table)
             .values(&NewHost {
                 ip: Some("10.0.0.1"),
+                scanner_id: None,
             })
             .execute(&mut conn)
             .unwrap();
@@ -572,6 +577,7 @@ mod tests {
         diesel::insert_into(nessus_hosts::table)
             .values(&NewHost {
                 ip: Some("10.0.0.1"),
+                scanner_id: None,
             })
             .execute(&mut conn)
             .unwrap();
@@ -640,6 +646,7 @@ mod tests {
         diesel::insert_into(nessus_hosts::table)
             .values(&NewHost {
                 ip: Some("10.0.0.1"),
+                scanner_id: None,
             })
             .execute(&mut conn)
             .unwrap();

--- a/src/template/host_template_helper.rs
+++ b/src/template/host_template_helper.rs
@@ -67,7 +67,7 @@ pub fn unsupported_os_appendix_section(report: &NessusReport) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::Item;
+    use crate::models::{Item, Scanner};
 
     fn sample_host() -> Host {
         Host {
@@ -85,6 +85,7 @@ mod tests {
             risk_score: None,
             user_id: None,
             engagement_id: None,
+            scanner_id: None,
         }
     }
 
@@ -137,6 +138,7 @@ mod tests {
             user_id: None,
             engagement_id: None,
             rollup_finding: Some(false),
+            scanner_id: None,
         };
         let report = NessusReport {
             report: crate::models::Report::default(),
@@ -155,6 +157,7 @@ mod tests {
             plugin_preferences: Vec::new(),
             server_preferences: Vec::new(),
             filters: crate::parser::Filters::default(),
+            scanner: Scanner::default(),
         };
 
         let out = unsupported_os_windows(&report);

--- a/src/template/scan_helper.rs
+++ b/src/template/scan_helper.rs
@@ -102,7 +102,7 @@ pub fn filter_summary(report: &NessusReport) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Host, Item, Report};
+    use crate::models::{Host, Item, Report, Scanner};
 
     fn sample_report() -> NessusReport {
         NessusReport {
@@ -123,6 +123,7 @@ mod tests {
                 risk_score: None,
                 user_id: None,
                 engagement_id: None,
+                scanner_id: None,
             }],
             items: vec![Item {
                 id: 1,
@@ -140,6 +141,7 @@ mod tests {
             plugin_preferences: Vec::new(),
             server_preferences: Vec::new(),
             filters: Default::default(),
+            scanner: Scanner::default(),
         }
     }
 

--- a/src/templates/unsupported_software.rs
+++ b/src/templates/unsupported_software.rs
@@ -80,7 +80,7 @@ pub static METADATA: Metadata = Metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Host, Item, Report};
+    use crate::models::{Host, Item, Report, Scanner};
     use crate::parser::Filters;
     use crate::renderers::Renderer;
     use std::io;
@@ -128,6 +128,7 @@ mod tests {
             risk_score: None,
             user_id: None,
             engagement_id: None,
+            scanner_id: None,
         }
     }
 
@@ -164,6 +165,7 @@ mod tests {
             user_id: None,
             engagement_id: None,
             rollup_finding: Some(false),
+            scanner_id: None,
         }
     }
 
@@ -185,6 +187,7 @@ mod tests {
             plugin_preferences: Vec::new(),
             server_preferences: Vec::new(),
             filters: Filters::default(),
+            scanner: Scanner::default(),
         }
     }
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -233,11 +233,13 @@ fn parses_nessus_sqlite_db() {
     #[diesel(table_name = nessus_hosts)]
     struct NewHost<'a> {
         ip: Option<&'a str>,
+        scanner_id: Option<i32>,
     }
 
     diesel::insert_into(nessus_hosts::table)
         .values(&NewHost {
             ip: Some("1.2.3.4"),
+            scanner_id: None,
         })
         .execute(&mut conn)
         .unwrap();

--- a/tests/postprocess.rs
+++ b/tests/postprocess.rs
@@ -19,6 +19,7 @@ fn host(name: &str, ip: Option<&str>) -> Host {
         risk_score: None,
         user_id: None,
         engagement_id: None,
+        scanner_id: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- track scanner details with new `scanners` table and `scanner_id` columns
- add `Scanner` model and associate hosts, items, and plugins with scanners
- update parsers and graph generation to filter by scanner

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae7a4c40808320aa85fc63c923aaac