### PR TITLE
Add database-backed graph modules and template helpers

### DIFF
--- a/src/graphs/host_severity_counts.rs
+++ b/src/graphs/host_severity_counts.rs
@@ -1,0 +1,111 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
+use plotters::prelude::*;
+
+use crate::schema::nessus_items::dsl::{
+    host_id, nessus_items, rollup_finding, scanner_id as sid_col, severity,
+};
+
+/// Generate a bar chart showing the number of hosts by their highest severity level.
+/// The result is saved to `dir/host_severity_counts.png` and the path is returned.
+pub struct HostSeverityCountsGraph;
+
+impl HostSeverityCountsGraph {
+    fn severity_label(val: i32) -> &'static str {
+        match val {
+            4 => "Critical",
+            3 => "High",
+            2 => "Medium",
+            1 => "Low",
+            _ => "Info",
+        }
+    }
+
+    pub fn generate(
+        conn: &mut SqliteConnection,
+        dir: &Path,
+        scanner: Option<i32>,
+    ) -> Result<PathBuf, Box<dyn Error>> {
+        let mut query = nessus_items
+            .select((host_id, severity))
+            .filter(
+                host_id
+                    .is_not_null()
+                    .and(severity.is_not_null())
+                    .and(rollup_finding.ne(true).or(rollup_finding.is_null())),
+            )
+            .into_boxed();
+        if let Some(sid) = scanner {
+            query = query.filter(sid_col.eq(sid));
+        }
+        let rows: Vec<(Option<i32>, Option<i32>)> = query.load(conn)?;
+
+        let mut host_max: HashMap<i32, i32> = HashMap::new();
+        for (hid, sev) in rows.into_iter() {
+            if let (Some(h), Some(s)) = (hid, sev) {
+                let entry = host_max.entry(h).or_insert(s);
+                if s > *entry {
+                    *entry = s;
+                }
+            }
+        }
+
+        let mut counts: HashMap<i32, i32> = HashMap::new();
+        for sev in host_max.values() {
+            *counts.entry(*sev).or_insert(0) += 1;
+        }
+
+        if counts.is_empty() {
+            return Err("no vulnerability data".into());
+        }
+
+        let mut data: Vec<(i32, i32)> = counts.into_iter().collect();
+        data.sort_by_key(|(sev, _)| *sev);
+        let labels: Vec<String> = data
+            .iter()
+            .map(|(sev, _)| Self::severity_label(*sev).to_string())
+            .collect();
+        let max_count = data.iter().map(|(_, c)| *c).max().unwrap_or(0);
+
+        let file = dir.join("host_severity_counts.png");
+        let tmp = file.clone();
+        let root = BitMapBackend::new(&tmp, (800, 600)).into_drawing_area();
+        root.fill(&WHITE)?;
+
+        let mut chart = ChartBuilder::on(&root)
+            .margin(20)
+            .caption("Hosts by Highest Severity", ("sans-serif", 30))
+            .x_label_area_size(40)
+            .y_label_area_size(40)
+            .build_cartesian_2d(0..data.len() as i32, 0..(max_count + 1))?;
+
+        chart
+            .configure_mesh()
+            .disable_mesh()
+            .x_labels(labels.len())
+            .x_label_formatter(&|x| {
+                let idx = *x as usize;
+                if idx < labels.len() {
+                    labels[idx].clone()
+                } else {
+                    String::new()
+                }
+            })
+            .draw()?;
+
+        chart.draw_series(data.iter().enumerate().map(|(i, (_, c))| {
+            Rectangle::new(
+                [(i as i32, 0), (i as i32 + 1, *c)],
+                Palette99::pick(i).filled(),
+            )
+        }))?;
+
+        root.present()?;
+        drop(root);
+        Ok(file)
+    }
+}

--- a/src/graphs/mod.rs
+++ b/src/graphs/mod.rs
@@ -5,105 +5,22 @@ use std::path::{Path, PathBuf};
 use plotters::prelude::*;
 
 use crate::parser::NessusReport;
-use windows_os::normalize_windows_os;
 
 pub mod top_vuln;
 pub mod windows_os;
 pub mod malware;
+pub mod os_distribution;
+pub mod vulns_by_service;
+pub mod vuln_category;
+pub mod host_severity_counts;
 
 pub use top_vuln::TopVulnGraph;
 pub use windows_os::WindowsOsGraph;
 pub use malware::malware;
-
-/// Generate a pie chart showing operating system distribution among hosts.
-/// Returns the path to the generated PNG file.
-pub(crate) fn count_os(report: &NessusReport) -> HashMap<String, usize> {
-    let mut counts: HashMap<String, usize> = HashMap::new();
-    for host in &report.hosts {
-        let os = host.os.clone().unwrap_or_else(|| "Unknown".to_string());
-        let os = normalize_windows_os(&os).to_string();
-        *counts.entry(os).or_default() += 1;
-    }
-    counts
-}
-
-pub fn os_distribution(report: &NessusReport, dir: &Path) -> Result<PathBuf, Box<dyn Error>> {
-    let counts = count_os(report);
-
-    if counts.is_empty() {
-        return Err("no host data".into());
-    }
-
-    let file = dir.join("os_distribution.png");
-    let tmp = file.clone();
-    let root = BitMapBackend::new(&tmp, (640, 480)).into_drawing_area();
-    root.fill(&WHITE)?;
-
-    let dims = root.dim_in_pixel();
-    let center = (dims.0 as i32 / 2, dims.1 as i32 / 2);
-    let radius = (dims.0.min(dims.1) as f64) * 0.4;
-
-    let mut sizes = Vec::new();
-    let mut colors = Vec::new();
-    let mut labels = Vec::new();
-    for (i, (os, count)) in counts.into_iter().enumerate() {
-        sizes.push(count as f64);
-        let (r, g, b) = Palette99::pick(i).rgb();
-        colors.push(RGBColor(r, g, b));
-        labels.push(os);
-    }
-    let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
-
-    let mut pie = Pie::new(&center, &radius, &sizes, &colors, &label_refs);
-    pie.label_style(("sans-serif", 15).into_font());
-    pie.percentages(("sans-serif", 12).into_font());
-    root.draw(&pie)?;
-    root.present()?;
-    drop(root);
-    Ok(file)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::models::Host;
-
-    fn host(os: &str) -> Host {
-        Host {
-            id: 0,
-            nessus_report_id: None,
-            name: None,
-            os: Some(os.to_string()),
-            mac: None,
-            start: None,
-            end: None,
-            ip: None,
-            fqdn: None,
-            netbios: None,
-            notes: None,
-            risk_score: None,
-            user_id: None,
-            engagement_id: None,
-            scanner_id: None,
-        }
-    }
-
-    #[test]
-    fn count_os_normalizes_windows_variants() {
-        let report = NessusReport {
-            hosts: vec![
-                host("Windows 2000"),
-                host("Microsoft Windows 2000 SP4"),
-                host("Windows XP"),
-                host("Microsoft Windows XP Professional"),
-            ],
-            ..NessusReport::default()
-        };
-        let counts = count_os(&report);
-        assert_eq!(counts.get("Windows 2000"), Some(&2));
-        assert_eq!(counts.get("Windows XP"), Some(&2));
-    }
-}
+pub use os_distribution::{count_os, os_distribution, OsDistributionGraph};
+pub use vulns_by_service::VulnsByServiceGraph;
+pub use vuln_category::VulnCategoryGraph;
+pub use host_severity_counts::HostSeverityCountsGraph;
 
 /// Generate a bar chart of the top `n` vulnerabilities by occurrence.
 /// Returns the path to the generated PNG file.

--- a/src/graphs/os_distribution.rs
+++ b/src/graphs/os_distribution.rs
@@ -1,0 +1,167 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
+use plotters::prelude::*;
+
+use crate::parser::NessusReport;
+use crate::schema::nessus_hosts::dsl::{nessus_hosts, os as host_os, scanner_id as host_scanner_id};
+
+use super::windows_os::normalize_windows_os;
+
+/// Count operating systems in a [`NessusReport`].
+pub fn count_os(report: &NessusReport) -> HashMap<String, usize> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for host in &report.hosts {
+        let os = host
+            .os
+            .clone()
+            .unwrap_or_else(|| "Unknown".to_string());
+        let os = normalize_windows_os(&os).to_string();
+        *counts.entry(os).or_default() += 1;
+    }
+    counts
+}
+
+/// Generate an OS distribution graph from a [`NessusReport`].
+pub fn os_distribution(report: &NessusReport, dir: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    let counts = count_os(report);
+
+    if counts.is_empty() {
+        return Err("no host data".into());
+    }
+
+    let file = dir.join("os_distribution.png");
+    let tmp = file.clone();
+    let root = BitMapBackend::new(&tmp, (640, 480)).into_drawing_area();
+    root.fill(&WHITE)?;
+
+    let dims = root.dim_in_pixel();
+    let center = (dims.0 as i32 / 2, dims.1 as i32 / 2);
+    let radius = (dims.0.min(dims.1) as f64) * 0.4;
+
+    let mut sizes = Vec::new();
+    let mut colors = Vec::new();
+    let mut labels = Vec::new();
+    for (i, (os, count)) in counts.into_iter().enumerate() {
+        sizes.push(count as f64);
+        let (r, g, b) = Palette99::pick(i).rgb();
+        colors.push(RGBColor(r, g, b));
+        labels.push(os);
+    }
+    let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+
+    let mut pie = Pie::new(&center, &radius, &sizes, &colors, &label_refs);
+    pie.label_style(("sans-serif", 15).into_font());
+    pie.percentages(("sans-serif", 12).into_font());
+    root.draw(&pie)?;
+    root.present()?;
+    drop(root);
+    Ok(file)
+}
+
+/// Generate an OS distribution graph from the database.
+///
+/// The resulting PNG is saved to `dir/os_distribution.png` and the path is
+/// returned.
+pub struct OsDistributionGraph;
+
+impl OsDistributionGraph {
+    fn count(results: Vec<Option<String>>) -> HashMap<String, usize> {
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for name in results.into_iter().flatten() {
+            let normalized = normalize_windows_os(&name).to_string();
+            *counts.entry(normalized).or_insert(0) += 1;
+        }
+        counts
+    }
+
+    pub fn generate(
+        conn: &mut SqliteConnection,
+        dir: &Path,
+        scanner: Option<i32>,
+    ) -> Result<PathBuf, Box<dyn Error>> {
+        let mut query = nessus_hosts.select(host_os).into_boxed();
+        if let Some(sid) = scanner {
+            query = query.filter(host_scanner_id.eq(sid));
+        }
+        let results: Vec<Option<String>> = query.load(conn)?;
+
+        let counts = Self::count(results);
+        if counts.is_empty() {
+            return Err("no host data".into());
+        }
+
+        let file = dir.join("os_distribution.png");
+        let tmp = file.clone();
+        let root = BitMapBackend::new(&tmp, (640, 480)).into_drawing_area();
+        root.fill(&WHITE)?;
+
+        let dims = root.dim_in_pixel();
+        let center = (dims.0 as i32 / 2, dims.1 as i32 / 2);
+        let radius = (dims.0.min(dims.1) as f64) * 0.4;
+
+        let mut sizes = Vec::new();
+        let mut colors = Vec::new();
+        let mut labels = Vec::new();
+        for (i, (name, count)) in counts.into_iter().enumerate() {
+            sizes.push(count as f64);
+            let (r, g, b) = Palette99::pick(i).rgb();
+            colors.push(RGBColor(r, g, b));
+            labels.push(name);
+        }
+        let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+
+        let mut pie = Pie::new(&center, &radius, &sizes, &colors, &label_refs);
+        pie.label_style(("sans-serif", 15).into_font());
+        pie.percentages(("sans-serif", 12).into_font());
+        root.draw(&pie)?;
+        root.present()?;
+        drop(root);
+        Ok(file)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::Host;
+
+    fn host(os: &str) -> Host {
+        Host {
+            id: 0,
+            nessus_report_id: None,
+            name: None,
+            os: Some(os.to_string()),
+            mac: None,
+            start: None,
+            end: None,
+            ip: None,
+            fqdn: None,
+            netbios: None,
+            notes: None,
+            risk_score: None,
+            user_id: None,
+            engagement_id: None,
+            scanner_id: None,
+        }
+    }
+
+    #[test]
+    fn count_os_normalizes_windows_variants() {
+        let report = NessusReport {
+            hosts: vec![
+                host("Windows 2000"),
+                host("Microsoft Windows 2000 SP4"),
+                host("Windows XP"),
+                host("Microsoft Windows XP Professional"),
+            ],
+            ..NessusReport::default()
+        };
+        let counts = count_os(&report);
+        assert_eq!(counts.get("Windows 2000"), Some(&2));
+        assert_eq!(counts.get("Windows XP"), Some(&2));
+    }
+}

--- a/src/graphs/vuln_category.rs
+++ b/src/graphs/vuln_category.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
+use plotters::prelude::*;
+
+use crate::schema::nessus_items::dsl::{
+    nessus_items, plugin_id as item_pid, rollup_finding, scanner_id as sid_col,
+};
+use crate::schema::nessus_plugins::dsl::{
+    family_name, nessus_plugins, plugin_id as plugin_pid,
+};
+
+/// Generate a bar chart of vulnerabilities grouped by plugin family/category.
+/// The resulting image is saved to `dir/vuln_categories.png` and the path is returned.
+pub struct VulnCategoryGraph;
+
+impl VulnCategoryGraph {
+    pub fn generate(
+        conn: &mut SqliteConnection,
+        dir: &Path,
+        limit: usize,
+        scanner: Option<i32>,
+    ) -> Result<PathBuf, Box<dyn Error>> {
+        let mut query = nessus_items
+            .inner_join(nessus_plugins.on(item_pid.eq(plugin_pid)))
+            .select(family_name)
+            .filter(
+                family_name
+                    .is_not_null()
+                    .and(rollup_finding.ne(true).or(rollup_finding.is_null())),
+            )
+            .into_boxed();
+        if let Some(sid) = scanner {
+            query = query.filter(sid_col.eq(sid));
+        }
+        let families: Vec<Option<String>> = query.load(conn)?;
+
+        let mut counts: HashMap<String, i32> = HashMap::new();
+        for fam in families.into_iter().flatten() {
+            *counts.entry(fam).or_insert(0) += 1;
+        }
+
+        let mut data: Vec<(String, i32)> = counts.into_iter().collect();
+        data.sort_by(|a, b| b.1.cmp(&a.1));
+        data.truncate(limit);
+
+        if data.is_empty() {
+            return Err("no vulnerability data".into());
+        }
+
+        let max_count = data.iter().map(|(_, c)| *c).max().unwrap_or(0);
+        let labels: Vec<String> = data.iter().map(|(n, _)| n.clone()).collect();
+
+        let file = dir.join("vuln_categories.png");
+        let tmp = file.clone();
+        let root = BitMapBackend::new(&tmp, (1024, 768)).into_drawing_area();
+        root.fill(&WHITE)?;
+
+        let mut chart = ChartBuilder::on(&root)
+            .margin(20)
+            .caption("Vulnerabilities by Category", ("sans-serif", 30))
+            .x_label_area_size(40)
+            .y_label_area_size(40)
+            .build_cartesian_2d(0..data.len() as i32, 0..(max_count + 1))?;
+
+        chart
+            .configure_mesh()
+            .disable_mesh()
+            .x_labels(labels.len())
+            .x_label_formatter(&|x| {
+                let idx = *x as usize;
+                if idx < labels.len() {
+                    let name = &labels[idx];
+                    if name.len() > 10 {
+                        format!("{}…", &name[..10])
+                    } else {
+                        name.clone()
+                    }
+                } else {
+                    String::new()
+                }
+            })
+            .draw()?;
+
+        chart.draw_series(data.iter().enumerate().map(|(i, (_, c))| {
+            Rectangle::new(
+                [(i as i32, 0), (i as i32 + 1, *c)],
+                Palette99::pick(i).filled(),
+            )
+        }))?;
+
+        root.present()?;
+        drop(root);
+        Ok(file)
+    }
+}

--- a/src/graphs/vulns_by_service.rs
+++ b/src/graphs/vulns_by_service.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use diesel::prelude::*;
+use diesel::sqlite::SqliteConnection;
+use plotters::prelude::*;
+
+use crate::schema::nessus_items::dsl::{
+    nessus_items, rollup_finding, scanner_id as sid_col, svc_name,
+};
+
+/// Generate a bar chart of vulnerabilities grouped by service name.
+/// The resulting image is saved to `dir/vulns_by_service.png` and the path is returned.
+pub struct VulnsByServiceGraph;
+
+impl VulnsByServiceGraph {
+    pub fn generate(
+        conn: &mut SqliteConnection,
+        dir: &Path,
+        limit: usize,
+        scanner: Option<i32>,
+    ) -> Result<PathBuf, Box<dyn Error>> {
+        let mut query = nessus_items
+            .select(svc_name)
+            .filter(
+                svc_name
+                    .is_not_null()
+                    .and(rollup_finding.ne(true).or(rollup_finding.is_null())),
+            )
+            .into_boxed();
+        if let Some(sid) = scanner {
+            query = query.filter(sid_col.eq(sid));
+        }
+        let services: Vec<Option<String>> = query.load(conn)?;
+
+        let mut counts: HashMap<String, i32> = HashMap::new();
+        for svc in services.into_iter().flatten() {
+            *counts.entry(svc).or_insert(0) += 1;
+        }
+
+        let mut data: Vec<(String, i32)> = counts.into_iter().collect();
+        data.sort_by(|a, b| b.1.cmp(&a.1));
+        data.truncate(limit);
+
+        if data.is_empty() {
+            return Err("no vulnerability data".into());
+        }
+
+        let max_count = data.iter().map(|(_, c)| *c).max().unwrap_or(0);
+        let labels: Vec<String> = data.iter().map(|(n, _)| n.clone()).collect();
+
+        let file = dir.join("vulns_by_service.png");
+        let tmp = file.clone();
+        let root = BitMapBackend::new(&tmp, (1024, 768)).into_drawing_area();
+        root.fill(&WHITE)?;
+
+        let mut chart = ChartBuilder::on(&root)
+            .margin(20)
+            .caption("Vulnerabilities by Service", ("sans-serif", 30))
+            .x_label_area_size(40)
+            .y_label_area_size(40)
+            .build_cartesian_2d(0..data.len() as i32, 0..(max_count + 1))?;
+
+        chart
+            .configure_mesh()
+            .disable_mesh()
+            .x_labels(labels.len())
+            .x_label_formatter(&|x| {
+                let idx = *x as usize;
+                if idx < labels.len() {
+                    let name = &labels[idx];
+                    if name.len() > 10 {
+                        format!("{}…", &name[..10])
+                    } else {
+                        name.clone()
+                    }
+                } else {
+                    String::new()
+                }
+            })
+            .draw()?;
+
+        chart.draw_series(data.iter().enumerate().map(|(i, (_, c))| {
+            Rectangle::new(
+                [(i as i32, 0), (i as i32 + 1, *c)],
+                Palette99::pick(i).filled(),
+            )
+        }))?;
+
+        root.present()?;
+        drop(root);
+        Ok(file)
+    }
+}

--- a/src/template/helpers.rs
+++ b/src/template/helpers.rs
@@ -7,7 +7,10 @@ use base64::{Engine, engine::general_purpose};
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 
-use crate::graphs::{TopVulnGraph, WindowsOsGraph};
+use crate::graphs::{
+    HostSeverityCountsGraph, OsDistributionGraph, TopVulnGraph, VulnCategoryGraph,
+    VulnsByServiceGraph, WindowsOsGraph,
+};
 use crate::models::{
     Attachment, FamilySelection, Host, HostProperty, Item, PolicyPlugin, ServiceDescription,
 };
@@ -52,6 +55,40 @@ pub fn top_vuln_graph(conn: &mut SqliteConnection) -> Result<String, Box<dyn Err
 pub fn windows_os_graph(conn: &mut SqliteConnection) -> Result<String, Box<dyn Error>> {
     let dir: PathBuf = std::env::temp_dir();
     let path = WindowsOsGraph::generate(conn, &dir)?;
+    let bytes = fs::read(path)?;
+    embed_graph(&bytes)
+}
+
+/// Generate a general OS distribution graph and return it as a data URI.
+pub fn os_distribution_graph(conn: &mut SqliteConnection) -> Result<String, Box<dyn Error>> {
+    let dir: PathBuf = std::env::temp_dir();
+    let path = OsDistributionGraph::generate(conn, &dir, None)?;
+    let bytes = fs::read(path)?;
+    embed_graph(&bytes)
+}
+
+/// Generate a vulnerabilities by service graph and return it as a data URI.
+pub fn vulns_by_service_graph(conn: &mut SqliteConnection) -> Result<String, Box<dyn Error>> {
+    let dir: PathBuf = std::env::temp_dir();
+    let path = VulnsByServiceGraph::generate(conn, &dir, 10, None)?;
+    let bytes = fs::read(path)?;
+    embed_graph(&bytes)
+}
+
+/// Generate a vulnerability category graph and return it as a data URI.
+pub fn vuln_category_graph(conn: &mut SqliteConnection) -> Result<String, Box<dyn Error>> {
+    let dir: PathBuf = std::env::temp_dir();
+    let path = VulnCategoryGraph::generate(conn, &dir, 10, None)?;
+    let bytes = fs::read(path)?;
+    embed_graph(&bytes)
+}
+
+/// Generate a host severity counts graph and return it as a data URI.
+pub fn host_severity_counts_graph(
+    conn: &mut SqliteConnection,
+) -> Result<String, Box<dyn Error>> {
+    let dir: PathBuf = std::env::temp_dir();
+    let path = HostSeverityCountsGraph::generate(conn, &dir, None)?;
     let bytes = fs::read(path)?;
     embed_graph(&bytes)
 }


### PR DESCRIPTION
## Summary
- Add OS distribution, vulnerabilities by service, vulnerability category, and host severity graphs backed by the database
- Provide template helpers to embed these graphs as data URIs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7e9a2a2c8320baaca1caebfccb08