### PR TITLE
Add unsupported OS template

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,7 @@ fn run() -> Result<(), error::Error> {
         manager.register(Box::new(templates::MissingRootCausesTemplate));
         manager.register(Box::new(templates::MSWSUSFindingsTemplate));
         manager.register(Box::new(templates::ServiceInventoryTemplate));
+        manager.register(Box::new(templates::UnsupportedOsTemplate));
         manager.load_templates().map_err(error::Error::Template)?;
         manager.display();
         return Ok(());
@@ -450,6 +451,7 @@ fn run() -> Result<(), error::Error> {
             manager.register(Box::new(templates::MissingRootCausesTemplate));
             manager.register(Box::new(templates::MSWSUSFindingsTemplate));
             manager.register(Box::new(templates::ServiceInventoryTemplate));
+            manager.register(Box::new(templates::UnsupportedOsTemplate));
             manager.load_templates().map_err(error::Error::Template)?;
             let mut template_args_map: HashMap<String, String> = cfg
                 .template_settings

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -33,6 +33,7 @@ pub mod talking_points;
 pub mod technical_findings;
 pub mod template;
 pub mod top_25;
+pub mod unsupported_os;
 pub mod unsupported_software;
 
 pub use assets::AssetsTemplate;
@@ -70,4 +71,5 @@ pub use talking_points::TalkingPointsTemplate;
 pub use technical_findings::TechnicalFindingsTemplate;
 pub use template::TemplateTemplate;
 pub use top_25::Top25Template;
+pub use unsupported_os::UnsupportedOsTemplate;
 pub use unsupported_software::UnsupportedSoftwareTemplate;

--- a/src/templates/unsupported_os.rs
+++ b/src/templates/unsupported_os.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+use std::error::Error;
+
+use crate::parser::NessusReport;
+use crate::renderer::Renderer;
+use crate::template::Template;
+use crate::template::host_template_helper::{unsupported_os_linux, unsupported_os_windows};
+
+/// Template that lists hosts running unsupported operating systems.
+pub struct UnsupportedOsTemplate;
+
+impl Template for UnsupportedOsTemplate {
+    fn name(&self) -> &str {
+        "unsupported_os"
+    }
+
+    fn generate(
+        &self,
+        report: &NessusReport,
+        renderer: &mut dyn Renderer,
+        _args: &HashMap<String, String>,
+    ) -> Result<(), Box<dyn Error>> {
+        renderer.heading(1, "Unsupported Operating Systems")?;
+
+        let windows = unsupported_os_windows(report);
+        let linux = unsupported_os_linux(report);
+
+        if windows.is_empty() && linux.is_empty() {
+            renderer.text("No unsupported operating systems detected.")?;
+            return Ok(());
+        }
+
+        if !windows.is_empty() {
+            renderer.text(&windows)?;
+        }
+        if !linux.is_empty() {
+            renderer.text(&linux)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Metadata about this template.
+pub struct Metadata {
+    pub name: &'static str,
+    pub author: &'static str,
+    pub renderer: &'static str,
+}
+
+pub static METADATA: Metadata = Metadata {
+    name: "unsupported_os",
+    author: "ported",
+    renderer: "text",
+};

--- a/tests/fixtures/unsupported_os.nessus
+++ b/tests/fixtures/unsupported_os.nessus
@@ -1,0 +1,16 @@
+<NessusClientData_v2>
+  <ReportHost name="winhost">
+    <HostProperties>
+      <tag name="host-ip">10.0.0.1</tag>
+      <tag name="operating-system-unsupported">Windows XP</tag>
+    </HostProperties>
+    <ReportItem pluginID="100000" port="0" svc_name="" protocol="tcp" severity="0" pluginName="Microsoft Windows XP Unsupported Installation Detection">
+    </ReportItem>
+  </ReportHost>
+  <ReportHost name="linuxhost">
+    <HostProperties>
+      <tag name="host-ip">10.0.0.2</tag>
+      <tag name="operating-system-unsupported">Ubuntu 10.04</tag>
+    </HostProperties>
+  </ReportHost>
+</NessusClientData_v2>

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -401,3 +401,13 @@ fn service_inventory_template_lists_services() {
         "ssh,22,SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.8",
     );
 }
+
+#[test]
+fn unsupported_os_template_lists_hosts() {
+    let out = render_template_capture_raw_fixture(
+        "unsupported_os",
+        "tests/fixtures/unsupported_os.nessus",
+    );
+    assert!(out.contains("winhost"));
+    assert!(out.contains("linuxhost"));
+}


### PR DESCRIPTION
## Summary
- add template listing hosts with unsupported Windows and Linux versions
- detect unsupported releases via new host template helper
- verify template output using fixture-based tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae8fcfac30832098c6d86d5f63243e