### PR TITLE
Add bug-report CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha2",
+ "sys-info",
  "tempfile",
  "thiserror 1.0.69",
  "tracing",
@@ -2089,6 +2090,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rustc_version_runtime = "0.3"
 cargo-lock = "10.1"
 lazy_static = "1.5"
 ipnet = "2.9"
+sys-info = "0.9"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ risu-rs parse scan.nessus -o report.pdf -t simple --whitelist 1001,1002
 risu-rs --list-templates           # list available templates
 risu-rs --list-post-process        # list post-process plugins
 risu-rs --search-output keyword    # find keyword in plugin output
+risu-rs --bug-report               # print environment details for bug reports
 ```
 
 Use `--blacklist` or `--whitelist` to control which plugin IDs are included in

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+/// Print environment details useful for filing bug reports.
+pub fn print(config_path: &Path) {
+    println!("Please include the following information when filing an issue:\n");
+    // Application and Rust versions via existing helper
+    crate::version::print();
+    // Database engine version
+    println!("sqlite {}", rusqlite::version());
+    // OS details
+    if let Ok(os_type) = sys_info::os_type() {
+        if let Ok(os_release) = sys_info::os_release() {
+            println!("os {os_type} {os_release}");
+        } else {
+            println!("os {os_type}");
+        }
+    }
+    // Configuration file location
+    println!("config file {}", config_path.display());
+    // Recent log lines if a log file exists in the current directory
+    let log_path = Path::new("risu.log");
+    if log_path.exists() {
+        println!("recent log lines from {}:", log_path.display());
+        if let Ok(log) = std::fs::read_to_string(log_path) {
+            let lines: Vec<_> = log.lines().rev().take(20).collect();
+            for line in lines.into_iter().rev() {
+                println!("  {line}");
+            }
+        }
+    }
+    println!("\nInclude the above output when filing an issue.");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 //! risu-rs parse scan.nessus -o out.csv -t simple --post-process
 //! risu-rs --list-templates           # list available templates
 //! risu-rs --list-post-process        # list post-process plugins
+//! risu-rs --bug-report               # print environment details for bug reports
 //! ```
 
 mod banner;
@@ -26,6 +27,7 @@ mod schema;
 mod template;
 mod templates;
 mod version;
+mod bug_report;
 
 use chrono::{Duration, Utc};
 use clap::{Parser, Subcommand};
@@ -53,6 +55,9 @@ struct Cli {
     /// Print application, Rust, and crate versions
     #[arg(long)]
     version: bool,
+    /// Print environment details for bug reports
+    #[arg(long = "bug-report")]
+    bug_report: bool,
     /// List available post-processing plugins
     #[arg(long = "list-post-process")]
     list_post_process: bool,
@@ -201,8 +206,18 @@ fn run() -> Result<(), error::Error> {
     }
     let cli = Cli::parse_from(args);
 
+    let config_path = cli
+        .config_file
+        .clone()
+        .unwrap_or_else(|| std::path::PathBuf::from("config.yml"));
+
     if cli.version {
         version::print();
+        return Ok(());
+    }
+
+    if cli.bug_report {
+        bug_report::print(&config_path);
         return Ok(());
     }
 
@@ -212,11 +227,6 @@ fn run() -> Result<(), error::Error> {
         cli.log_level.as_str()
     };
     init_logging(level, &cli.log_format);
-
-    let config_path = cli
-        .config_file
-        .clone()
-        .unwrap_or_else(|| std::path::PathBuf::from("config.yml"));
 
     if let Some(path_opt) = cli.create_config_file {
         let path = path_opt.unwrap_or_else(|| config_path.clone());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -152,6 +152,17 @@ fn list_post_process_shows_plugins() {
 }
 
 #[test]
+fn bug_report_shows_environment() {
+    let assert = Command::cargo_bin("risu-rs")
+        .unwrap()
+        .args(["--no-banner", "--bug-report"])
+        .assert()
+        .success();
+    let output = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(output.contains("Include the above output"));
+}
+
+#[test]
 fn parse_invalid_input_displays_error() {
     let tmp = tempdir().unwrap();
     Command::cargo_bin("risu-rs")


### PR DESCRIPTION
## Summary
- add `--bug-report` flag to print environment details for issue reports
- show Rust, application, SQLite, and OS versions plus config path
- test and document the new bug-report command

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae952814d08320b1bf9cd0d265a725