### PR TITLE
feat: add bug report flag and utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ risu-rs --search-output keyword    # find keyword in plugin output
 risu-rs --bug-report               # print environment details for bug reports
 ```
 
+When reporting issues, run `risu-rs --bug-report` and include the generated
+output in your bug report to help with troubleshooting.
+
 Use `--blacklist` or `--whitelist` to control which plugin IDs are included in
 the parsed report. Both options accept comma-separated ID lists. When a
 whitelist is provided, only matching plugin IDs are kept; blacklisted IDs are

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 /// Print environment details useful for filing bug reports.
 pub fn print(config_path: &Path) {
     println!("Please include the following information when filing an issue:\n");
+
     // Application and Rust versions via existing helper
     crate::version::print();
-    // Database engine version
-    println!("sqlite {}", rusqlite::version());
+
     // OS details
     if let Ok(os_type) = sys_info::os_type() {
         if let Ok(os_release) = sys_info::os_release() {
@@ -15,18 +15,26 @@ pub fn print(config_path: &Path) {
             println!("os {os_type}");
         }
     }
-    // Configuration file location
-    println!("config file {}", config_path.display());
-    // Recent log lines if a log file exists in the current directory
-    let log_path = Path::new("risu.log");
-    if log_path.exists() {
-        println!("recent log lines from {}:", log_path.display());
-        if let Ok(log) = std::fs::read_to_string(log_path) {
-            let lines: Vec<_> = log.lines().rev().take(20).collect();
-            for line in lines.into_iter().rev() {
-                println!("  {line}");
+
+    // Database backend information
+    let cfg = crate::config::load_config(config_path).unwrap_or_default();
+    println!("database {}", cfg.database_url);
+    println!("sqlite {}", rusqlite::version());
+
+    // Recent log files in the current directory
+    if let Ok(entries) = std::fs::read_dir(".") {
+        let mut logs: Vec<_> = entries
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("log"))
+            .collect();
+        logs.sort();
+        if !logs.is_empty() {
+            println!("recent log files:");
+            for path in logs.iter().take(5) {
+                println!("  {}", path.display());
             }
         }
     }
+
     println!("\nInclude the above output when filing an issue.");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ struct Cli {
     /// Print application, Rust, and crate versions
     #[arg(long)]
     version: bool,
-    /// Print environment details for bug reports
+    /// Collect environment details for bug reports
     #[arg(long = "bug-report")]
     bug_report: bool,
     /// List available post-processing plugins


### PR DESCRIPTION
## Summary
- add `--bug-report` flag to CLI to collect environment details
- implement bug_report::print to gather tool, OS, DB, and log information
- document using the new flag when filing issues

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ae9a8fcc3c8320a476ecd352d42aed