### PR TITLE
Add RTF renderer and CLI option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,8 +121,8 @@ enum Commands {
         /// Run post-processing plugins on the parsed data
         #[arg(long)]
         post_process: bool,
-        /// Renderer to use (pdf, csv, nil). Use `nil` to discard output.
-        #[arg(long, value_parser = ["pdf", "csv", "nil"])]
+        /// Renderer to use (pdf, csv, rtf, nil). Use `nil` to discard output.
+        #[arg(long, value_parser = ["pdf", "csv", "rtf", "nil"])]
         renderer: Option<String>,
         /// Template-specific arguments as `key=value` pairs
         #[arg(long = "template-arg", value_name = "key=value", value_parser = parse_key_val::<String, String>)]
@@ -167,8 +167,8 @@ enum Commands {
         /// Template author
         #[arg(long)]
         author: Option<String>,
-        /// Renderer type (pdf, csv, nil)
-        #[arg(long, value_parser = ["pdf", "csv", "nil"])]
+        /// Renderer type (pdf, csv, rtf, nil)
+        #[arg(long, value_parser = ["pdf", "csv", "rtf", "nil"])]
         renderer: Option<String>,
     },
 }

--- a/src/renderers/mod.rs
+++ b/src/renderers/mod.rs
@@ -3,10 +3,12 @@ use std::{error::Error, io::Write};
 mod pdf;
 mod csv;
 mod nil;
+mod rtf;
 
 pub use csv::CsvRenderer;
 pub use nil::NilRenderer;
 pub use pdf::PdfRenderer;
+pub use rtf::RtfRenderer;
 
 /// Trait implemented by renderers that output to various formats.
 pub trait Renderer {

--- a/src/renderers/rtf.rs
+++ b/src/renderers/rtf.rs
@@ -1,0 +1,92 @@
+use std::{error::Error, io::Write};
+
+use super::Renderer;
+
+/// Renderer that produces RTF documents.
+pub struct RtfRenderer {
+    content: String,
+}
+
+impl RtfRenderer {
+    /// Create a new RTF renderer.
+    pub fn new() -> Self {
+        Self {
+            content: String::from("{\\rtf1\\ansi\\deff0\n"),
+        }
+    }
+
+    fn escape(text: &str) -> String {
+        text.replace('\\', "\\\\")
+            .replace('{', "\\{")
+            .replace('}', "\\}")
+    }
+
+    /// Insert a simple table. Each inner slice is a row.
+    pub fn table(&mut self, rows: &[Vec<&str>]) -> Result<(), Box<dyn Error>> {
+        for row in rows {
+            self.content.push_str("\\trowd ");
+            let mut cellx = 1000;
+            for _ in row {
+                self.content.push_str(&format!("\\cellx{}", cellx));
+                cellx += 1000;
+            }
+            for cell in row {
+                let esc = Self::escape(cell);
+                self.content.push_str(&format!("{esc}\\cell "));
+            }
+            self.content.push_str("\\row\n");
+        }
+        Ok(())
+    }
+
+    /// Embed an image from raw bytes (PNG/JPEG).
+    pub fn image(&mut self, data: &[u8]) -> Result<(), Box<dyn Error>> {
+        let hex: String = data.iter().map(|b| format!("{:02x}", b)).collect();
+        self.content
+            .push_str(&format!("{{\\pict\\pngblip {hex}}}\\par\n"));
+        Ok(())
+    }
+}
+
+impl Renderer for RtfRenderer {
+    fn text(&mut self, text: &str) -> Result<(), Box<dyn Error>> {
+        let esc = Self::escape(text);
+        self.content.push_str(&format!("{esc}\\par\n"));
+        Ok(())
+    }
+
+    fn start_new_page(&mut self) -> Result<(), Box<dyn Error>> {
+        self.content.push_str("\\page\n");
+        Ok(())
+    }
+
+    fn save(&mut self, writer: &mut dyn Write) -> Result<(), Box<dyn Error>> {
+        self.content.push('}');
+        writer.write_all(self.content.as_bytes())?;
+        Ok(())
+    }
+
+    fn heading(&mut self, _level: usize, text: &str) -> Result<(), Box<dyn Error>> {
+        let esc = Self::escape(text);
+        self.content.push_str(&format!("{{\\b {esc}\\b0}}\\par\n"));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Renderer;
+    use super::RtfRenderer;
+
+    #[test]
+    fn writes_basic_rtf() {
+        let mut r = RtfRenderer::new();
+        r.heading(1, "Title").unwrap();
+        r.text("Hello").unwrap();
+        let mut out = Vec::new();
+        r.save(&mut out).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.starts_with("{\\rtf1"));
+        assert!(s.contains("Title"));
+    }
+}

--- a/src/template/templater.rs
+++ b/src/template/templater.rs
@@ -61,8 +61,10 @@ impl<'a> Templater<'a> {
             Some("csv") => Box::new(renderer::CsvRenderer::new()),
             Some("nil") => Box::new(renderer::NilRenderer::new()),
             Some("pdf") => Box::new(renderer::PdfRenderer::new(&title_arg)),
+            Some("rtf") => Box::new(renderer::RtfRenderer::new()),
             None => match self.output.extension().and_then(|s| s.to_str()) {
                 Some("csv") => Box::new(renderer::CsvRenderer::new()),
+                Some("rtf") => Box::new(renderer::RtfRenderer::new()),
                 _ => Box::new(renderer::PdfRenderer::new(&title_arg)),
             },
             Some(other) => {

--- a/tests/rtf.rs
+++ b/tests/rtf.rs
@@ -1,0 +1,40 @@
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn parse_to_rtf_creates_file() {
+    let tmp = tempdir().unwrap();
+    let sample = fs::canonicalize("tests/fixtures/sample.nessus").unwrap();
+
+    Command::cargo_bin("risu-rs")
+        .unwrap()
+        .args(["--no-banner", "--create-config-file"])
+        .current_dir(&tmp)
+        .assert()
+        .success();
+
+    let output = tmp.path().join("out.rtf");
+    Command::cargo_bin("risu-rs")
+        .unwrap()
+        .current_dir(&tmp)
+        .args([
+            "--no-banner",
+            "--config-file",
+            "config.yml",
+            "parse",
+            sample.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "-t",
+            "simple",
+            "--renderer",
+            "rtf",
+        ])
+        .assert()
+        .success();
+
+    let contents = fs::read_to_string(output).unwrap();
+    assert!(contents.starts_with("{\\rtf"));
+    assert!(contents.contains("Simple Report"));
+}


### PR DESCRIPTION
## Summary
- implement basic RTF renderer with table and image helpers
- expose RTF renderer in library and CLI, allowing `--renderer rtf`
- add smoke test verifying RTF rendering

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aef3cc99b4832097df3072fa3a1a54