### PR TITLE
Add virtual machine summary template

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -392,6 +392,7 @@ fn run() -> Result<(), error::Error> {
         manager.register(Box::new(templates::MSWSUSFindingsTemplate));
         manager.register(Box::new(templates::ServiceInventoryTemplate));
         manager.register(Box::new(templates::UnsupportedOsTemplate));
+        manager.register(Box::new(templates::VirtualMachineSummaryTemplate));
         manager.load_templates().map_err(error::Error::Template)?;
         manager.display();
         return Ok(());
@@ -528,6 +529,7 @@ fn run() -> Result<(), error::Error> {
             manager.register(Box::new(templates::MSWSUSFindingsTemplate));
             manager.register(Box::new(templates::ServiceInventoryTemplate));
             manager.register(Box::new(templates::UnsupportedOsTemplate));
+            manager.register(Box::new(templates::VirtualMachineSummaryTemplate));
             manager.load_templates().map_err(error::Error::Template)?;
             let mut template_args_map: HashMap<String, String> = cfg
                 .template_settings

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -36,6 +36,7 @@ pub mod template;
 pub mod top_25;
 pub mod unsupported_os;
 pub mod unsupported_software;
+pub mod virtual_machine_summary;
 
 pub use assets::AssetsTemplate;
 pub use authentication_summary::AuthenticationSummaryTemplate;
@@ -75,3 +76,4 @@ pub use template::TemplateTemplate;
 pub use top_25::Top25Template;
 pub use unsupported_os::UnsupportedOsTemplate;
 pub use unsupported_software::UnsupportedSoftwareTemplate;
+pub use virtual_machine_summary::VirtualMachineSummaryTemplate;

--- a/src/templates/virtual_machine_summary.rs
+++ b/src/templates/virtual_machine_summary.rs
@@ -1,0 +1,91 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::error::Error;
+
+use crate::parser::NessusReport;
+use crate::renderer::Renderer;
+use crate::template::Template;
+
+/// Template that lists virtual machines detected by plugin 20094 grouped by hypervisor type.
+pub struct VirtualMachineSummaryTemplate;
+
+impl VirtualMachineSummaryTemplate {
+    fn detect_hypervisor(output: Option<&String>) -> &'static str {
+        let Some(out) = output else { return "Unknown" };
+        let lower = out.to_lowercase();
+        if lower.contains("vmware") {
+            "VMware"
+        } else if lower.contains("hyper-v") || lower.contains("hyperv") {
+            "Hyper-V"
+        } else if lower.contains("virtualbox") {
+            "VirtualBox"
+        } else if lower.contains("xen") {
+            "Xen"
+        } else if lower.contains("kvm") {
+            "KVM"
+        } else if lower.contains("parallels") {
+            "Parallels"
+        } else {
+            "Unknown"
+        }
+    }
+}
+
+impl Template for VirtualMachineSummaryTemplate {
+    fn name(&self) -> &str {
+        "virtual_machine_summary"
+    }
+
+    fn generate(
+        &self,
+        report: &NessusReport,
+        renderer: &mut dyn Renderer,
+        _args: &HashMap<String, String>,
+    ) -> Result<(), Box<dyn Error>> {
+        const PLUGIN_ID: i32 = 20094;
+        renderer.heading(1, "Virtual Machine Summary")?;
+        let mut groups: BTreeMap<&'static str, BTreeSet<String>> = BTreeMap::new();
+        let vm_items: Vec<_> = report
+            .items
+            .iter()
+            .filter(|it| it.plugin_id == Some(PLUGIN_ID))
+            .collect();
+        for (idx, item) in vm_items.iter().enumerate() {
+            let Some(host) = report.hosts.get(idx) else {
+                continue;
+            };
+            let host_name = host
+                .name
+                .clone()
+                .or(host.fqdn.clone())
+                .or(host.ip.clone())
+                .or(host.netbios.clone())
+                .unwrap_or_else(|| "unknown".into());
+            let hv = Self::detect_hypervisor(item.plugin_output.as_ref());
+            groups.entry(hv).or_default().insert(host_name);
+        }
+        if groups.is_empty() {
+            renderer.text("No virtual machines detected.")?;
+            return Ok(());
+        }
+        for (hv, hosts) in groups {
+            renderer.heading(2, hv)?;
+            for host in hosts {
+                renderer.text(&host)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Metadata about this template.
+pub struct Metadata {
+    pub name: &'static str,
+    pub author: &'static str,
+    pub renderer: &'static str,
+}
+
+pub static METADATA: Metadata = Metadata {
+    name: "virtual_machine_summary",
+    author: "ported",
+    renderer: "text",
+};

--- a/tests/fixtures/virtual_machines.nessus
+++ b/tests/fixtures/virtual_machines.nessus
@@ -1,0 +1,18 @@
+<NessusClientData_v2>
+  <ReportHost name="vmwarehost">
+    <HostProperties>
+      <tag name="host-ip">10.0.0.1</tag>
+    </HostProperties>
+    <ReportItem pluginID="20094" port="0" svc_name="" protocol="tcp" severity="0" pluginName="Virtual Machine Detection">
+      <plugin_output>Hypervisor: VMware</plugin_output>
+    </ReportItem>
+  </ReportHost>
+  <ReportHost name="hypervhost">
+    <HostProperties>
+      <tag name="host-ip">10.0.0.2</tag>
+    </HostProperties>
+    <ReportItem pluginID="20094" port="0" svc_name="" protocol="tcp" severity="0" pluginName="Virtual Machine Detection">
+      <plugin_output>Hypervisor: Hyper-V</plugin_output>
+    </ReportItem>
+  </ReportHost>
+</NessusClientData_v2>

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -420,3 +420,15 @@ fn microsoft_windows_unquoted_service_path_enumeration_template_lists_hosts() {
         "winhost",
     );
 }
+
+#[test]
+fn virtual_machine_summary_template_lists_hosts() {
+    let out = render_template_capture_raw_fixture(
+        "virtual_machine_summary",
+        "tests/fixtures/virtual_machines.nessus",
+    );
+    assert!(out.contains("vmwarehost"));
+    assert!(out.contains("hypervhost"));
+    assert!(out.contains("VMware"));
+    assert!(out.contains("Hyper-V"));
+}


### PR DESCRIPTION
## Summary
- add template to summarize virtual machines detected by plugin 20094
- register template and include fixture-based test

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aef88d5b0083209932ba3ef044ed8c