### PR TITLE
Add Nessus Patch model and parser support

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -9,6 +9,7 @@ pub mod family_selection;
 pub mod host;
 pub mod host_property;
 pub mod item;
+pub mod patch;
 pub mod plugin_metadata;
 pub mod plugin_preference;
 pub mod policy;
@@ -24,6 +25,7 @@ pub use attachment::Attachment;
 pub use family_selection::FamilySelection;
 pub use host_property::HostProperty;
 pub use item::Item;
+pub use patch::Patch;
 pub use plugin_metadata::NessusPluginMetadata;
 pub use plugin_preference::PluginPreference;
 pub use policy::Policy;
@@ -38,7 +40,7 @@ use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use std::net::IpAddr;
 
-use crate::schema::{nessus_hosts, nessus_patches, nessus_plugins};
+use crate::schema::{nessus_hosts, nessus_plugins};
 
 #[derive(Debug, Queryable, Identifiable, Associations)]
 #[diesel(belongs_to(Report, foreign_key = nessus_report_id))]
@@ -113,31 +115,6 @@ pub struct Plugin {
     pub scanner_id: Option<i32>,
 }
 
-#[derive(Debug, Queryable, Identifiable, Associations)]
-#[diesel(belongs_to(Host, foreign_key = host_id))]
-#[diesel(table_name = nessus_patches)]
-pub struct Patch {
-    pub id: i32,
-    pub host_id: Option<i32>,
-    pub name: Option<String>,
-    pub value: Option<String>,
-    pub user_id: Option<i32>,
-    pub engagement_id: Option<i32>,
-}
-
-impl Default for Patch {
-    fn default() -> Self {
-        Self {
-            id: 0,
-            host_id: None,
-            name: None,
-            value: None,
-            user_id: None,
-            engagement_id: None,
-        }
-    }
-}
-
 impl Default for Plugin {
     fn default() -> Self {
         Self {
@@ -193,10 +170,7 @@ impl Default for Plugin {
 }
 
 impl Host {
-    pub fn sorted(
-        conn: &mut SqliteConnection,
-        scanner: Option<i32>,
-    ) -> QueryResult<Vec<Host>> {
+    pub fn sorted(conn: &mut SqliteConnection, scanner: Option<i32>) -> QueryResult<Vec<Host>> {
         use crate::schema::nessus_hosts::dsl::*;
         let mut query = nessus_hosts.filter(ip.is_not_null()).into_boxed();
         if let Some(sid) = scanner {

--- a/src/models/patch.rs
+++ b/src/models/patch.rs
@@ -1,0 +1,29 @@
+use diesel::prelude::*;
+
+use crate::models::Host;
+use crate::schema::nessus_patches;
+
+#[derive(Debug, Queryable, Identifiable, Associations)]
+#[diesel(belongs_to(Host, foreign_key = host_id))]
+#[diesel(table_name = nessus_patches)]
+pub struct Patch {
+    pub id: i32,
+    pub host_id: Option<i32>,
+    pub name: Option<String>,
+    pub value: Option<String>,
+    pub user_id: Option<i32>,
+    pub engagement_id: Option<i32>,
+}
+
+impl Default for Patch {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            host_id: None,
+            name: None,
+            value: None,
+            user_id: None,
+            engagement_id: None,
+        }
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,15 +15,15 @@ use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
 use ipnet::IpNet;
-use quick_xml::events::Event;
 use quick_xml::Reader;
+use quick_xml::events::Event;
 use tracing::{debug, info};
 
 use crate::models::{
     Attachment, FamilySelection, Host, HostProperty, Item, Patch, Plugin, PluginPreference, Policy,
     PolicyPlugin, Reference, Report, Scanner, ServerPreference, ServiceDescription,
 };
-use base64::{engine::general_purpose, Engine};
+use base64::{Engine, engine::general_purpose};
 use chrono::NaiveDateTime;
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -471,6 +471,7 @@ fn parse_nessus(path: &Path, scanner_name: &str) -> Result<NessusReport, crate::
     let mut current_host: Option<Host> = None;
     let mut current_tag: Option<String> = None;
     let mut current_patches: Vec<Patch> = Vec::new();
+    let mut current_patch: Option<Patch> = None;
     let mut current_host_properties: Vec<HostProperty> = Vec::new();
     let mut current_service_descriptions: Vec<ServiceDescription> = Vec::new();
     let mut pending_service_description: Option<ServiceDescription> = None;
@@ -547,6 +548,31 @@ fn parse_nessus(path: &Path, scanner_name: &str) -> Result<NessusReport, crate::
                 }
                 b"HostProperties" => {
                     // nothing to do, tags will follow
+                }
+                b"patches" => {
+                    // container for patch entries
+                }
+                b"patch" => {
+                    if current_host.is_some() {
+                        let mut patch = empty_patch();
+                        for a in e.attributes().flatten() {
+                            match a.key.as_ref() {
+                                b"name" => {
+                                    patch.name = Some(a.unescape_value()?.to_string());
+                                }
+                                b"value" | b"kb" | b"id" | b"version" => {
+                                    patch.value = Some(a.unescape_value()?.to_string());
+                                }
+                                _ => {
+                                    unknown_attrs.insert(format!(
+                                        "patch {}",
+                                        String::from_utf8_lossy(a.key.as_ref())
+                                    ));
+                                }
+                            }
+                        }
+                        current_patch = Some(patch);
+                    }
                 }
                 b"tag" => {
                     for a in e.attributes().flatten() {
@@ -724,8 +750,41 @@ fn parse_nessus(path: &Path, scanner_name: &str) -> Result<NessusReport, crate::
                     }
                 }
             },
+            Event::Empty(e) => match e.name().as_ref() {
+                b"patch" => {
+                    if current_host.is_some() {
+                        let mut patch = empty_patch();
+                        for a in e.attributes().flatten() {
+                            match a.key.as_ref() {
+                                b"name" => {
+                                    patch.name = Some(a.unescape_value()?.to_string());
+                                }
+                                b"value" | b"kb" | b"id" | b"version" => {
+                                    patch.value = Some(a.unescape_value()?.to_string());
+                                }
+                                _ => {
+                                    unknown_attrs.insert(format!(
+                                        "patch {}",
+                                        String::from_utf8_lossy(a.key.as_ref())
+                                    ));
+                                }
+                            }
+                        }
+                        current_patches.push(patch);
+                    }
+                }
+                b"patches" => {}
+                _ => {
+                    let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    unknown_elements.insert(name);
+                }
+            },
             Event::Text(e) => {
-                if let Some(r) = &mut current_reference {
+                if let Some(p) = &mut current_patch {
+                    if p.value.is_none() {
+                        p.value = Some(e.unescape()?.into_owned());
+                    }
+                } else if let Some(r) = &mut current_reference {
                     r.value.push_str(&e.unescape()?.into_owned());
                 } else if let Some(att) = &mut current_attachment {
                     att.data.push_str(&e.unescape()?.into_owned());
@@ -1023,6 +1082,12 @@ fn parse_nessus(path: &Path, scanner_name: &str) -> Result<NessusReport, crate::
                 }
             }
             Event::End(e) => match e.name().as_ref() {
+                b"patch" => {
+                    if let Some(p) = current_patch.take() {
+                        current_patches.push(p);
+                    }
+                }
+                b"patches" => {}
                 b"tag" => {
                     current_tag = None;
                 }
@@ -1318,20 +1383,21 @@ mod tests {
         assert_eq!(report.patches.len(), 1);
         assert_eq!(report.patches[0].name.as_deref(), Some("MS12-001"));
         assert_eq!(report.patches[0].value.as_deref(), Some("KB123456"));
-        assert_eq!(report.host_properties.len(), 13);
-        assert!(report
-            .host_properties
-            .iter()
-            .any(|p| p.name.as_deref() == Some("host-ip")
-                && p.value.as_deref() == Some("192.168.0.1")));
-        assert!(report
-            .host_properties
-            .iter()
-            .any(|p| p.name.as_deref() == Some("operating-system")
-                && p.value.as_deref() == Some("Linux")));
-        assert!(report.host_properties.iter().any(
-            |p| p.name.as_deref() == Some("MS12-001") && p.value.as_deref() == Some("KB123456")
-        ));
+        assert_eq!(report.host_properties.len(), 12);
+        assert!(
+            report
+                .host_properties
+                .iter()
+                .any(|p| p.name.as_deref() == Some("host-ip")
+                    && p.value.as_deref() == Some("192.168.0.1"))
+        );
+        assert!(
+            report
+                .host_properties
+                .iter()
+                .any(|p| p.name.as_deref() == Some("operating-system")
+                    && p.value.as_deref() == Some("Linux"))
+        );
     }
 
     #[test]
@@ -1406,24 +1472,32 @@ mod tests {
         std::fs::write(&file_path, xml).unwrap();
         let report = parse_file(&file_path).expect("parse");
         assert_eq!(report.references.len(), 5);
-        assert!(report
-            .references
-            .iter()
-            .any(|r| r.source.as_deref() == Some("CVE")
-                && r.value.as_deref() == Some("CVE-2023-1111")));
-        assert!(report
-            .references
-            .iter()
-            .any(|r| r.source.as_deref() == Some("BID") && r.value.as_deref() == Some("BID-7654")));
-        assert!(report
-            .references
-            .iter()
-            .any(|r| r.source.as_deref() == Some("CVE")
-                && r.value.as_deref() == Some("CVE-2023-2222")));
-        assert!(report
-            .references
-            .iter()
-            .any(|r| r.source.as_deref() == Some("OSVDB") && r.value.as_deref() == Some("12345")));
+        assert!(
+            report
+                .references
+                .iter()
+                .any(|r| r.source.as_deref() == Some("CVE")
+                    && r.value.as_deref() == Some("CVE-2023-1111"))
+        );
+        assert!(
+            report
+                .references
+                .iter()
+                .any(|r| r.source.as_deref() == Some("BID")
+                    && r.value.as_deref() == Some("BID-7654"))
+        );
+        assert!(
+            report
+                .references
+                .iter()
+                .any(|r| r.source.as_deref() == Some("CVE")
+                    && r.value.as_deref() == Some("CVE-2023-2222"))
+        );
+        assert!(
+            report.references.iter().any(
+                |r| r.source.as_deref() == Some("OSVDB") && r.value.as_deref() == Some("12345")
+            )
+        );
         assert!(
             report
                 .references

--- a/src/templates/ms_patch_summary.rs
+++ b/src/templates/ms_patch_summary.rs
@@ -26,7 +26,7 @@ impl Template for MSPatchSummaryTemplate {
         renderer.text(title)?;
         for patch in &report.patches {
             if let Some(host_id) = patch.host_id {
-                if let Some(host) = report.hosts.get(host_id as usize) {
+                if let Some(host) = report.hosts.iter().find(|h| h.id == host_id) {
                     if let Some(name) = &host.name {
                         renderer.text(&format!("Host: {name}"))?;
                     }

--- a/tests/fixtures/sample.nessus
+++ b/tests/fixtures/sample.nessus
@@ -13,8 +13,10 @@
       <tag name="pcidss:status">passed</tag>
       <tag name="pcidss:compliant">yes</tag>
       <tag name="unknown-prop">foo</tag>
-      <tag name="MS12-001">KB123456</tag>
     </HostProperties>
+    <patches>
+      <patch name="MS12-001" version="KB123456" />
+    </patches>
     <ReportItem pluginID="100" port="0" svc_name="" protocol="tcp" severity="0" pluginName="Test Plugin">
     </ReportItem>
     <unknown-tag></unknown-tag>

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -225,7 +225,7 @@ fn notable_template_includes_high_severity_findings() {
 
 #[test]
 fn ms_update_summary_template_renders() {
-    run_template("ms_update_summary", "Missing Microsoft Updates");
+    run_template("ms_update_summary", "Patches: 1");
 }
 
 #[test]
@@ -434,6 +434,11 @@ fn missing_root_causes_template_renders() {
 #[test]
 fn ms_wsus_findings_template_renders() {
     run_template("ms_wsus_findings", "Patch Management: WSUS Report");
+}
+
+#[test]
+fn ms_patch_summary_template_renders() {
+    run_template("ms_patch_summary", "Patch: MS12-001");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Patch model and expose in models module
- parse `<patch>` elements in Nessus reports and surface via templates
- test Microsoft patch templates with sample report patches

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68af7a724c0c832081264c0a54d3fefd