### PR TITLE
Add basic docs with installation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A Rust rewrite of the Risu reporting utilities.
 
+## Documentation
+
+- [News](docs/NEWS.markdown)
+- [Installation Guides](docs/install_guides/README.markdown)
+- [Known Issues](docs/known_issues.markdown)
+
 ## Command-line usage
 
 ```bash

--- a/docs/NEWS.markdown
+++ b/docs/NEWS.markdown
@@ -1,0 +1,8 @@
+# News
+
+## v0.2.0
+- Restructured documentation and added installation guides.
+- Updated references to Rust build tools.
+
+## v0.1.0
+- Initial release of the Rust rewrite.

--- a/docs/install_guides/README.markdown
+++ b/docs/install_guides/README.markdown
@@ -1,0 +1,18 @@
+# Installation Guides
+
+## Prerequisites
+- Install Rust via [`rustup`](https://rustup.rs/).
+- Ensure `~/.cargo/bin` is on your `PATH` so the `cargo` and `risu-rs` commands are available.
+
+## Build from source
+```bash
+git clone https://github.com/example/risu-rs.git
+cd risu-rs
+cargo build --release
+```
+
+## Install locally
+```bash
+cargo install --path .
+```
+This places the compiled binary in `~/.cargo/bin/`.

--- a/docs/known_issues.markdown
+++ b/docs/known_issues.markdown
@@ -1,0 +1,5 @@
+# Known Issues
+
+- Building with the `mysql` feature requires the MySQL client libraries to be present.
+- SQLite builds need the `libsqlite3` development headers installed.
+- Some features may require a recent Rust toolchain; run `rustup update` to stay current.


### PR DESCRIPTION
## Summary
- add new docs directory with news, installation guide, and known issues
- link docs from README

## Testing
- `cargo test` *(fails: process hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68af83000fe88320824487d479d69484