### PR TITLE
Add checksum generation tool for releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,7 @@ default = ["sqlite"]
 sqlite = ["diesel/sqlite", "diesel_migrations/sqlite"]
 postgres = ["diesel/postgres", "diesel_migrations/postgres"]
 mysql = ["diesel/mysql", "diesel_migrations/mysql"]
+
+[[bin]]
+name = "checksum"
+path = "tools/checksum.rs"

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,15 @@ BINARIES := risu-rs
 TARGET_DIR := target/release
 CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
-.PHONY: build hash tag push publish release clean test test-sqlite test-postgres test-mysql notify
+.PHONY: build checksum tag push publish release clean test test-sqlite test-postgres test-mysql notify
 
 ## Build optimized binaries
 build:
 	cargo build --release
 
-## Generate SHA256 and SHA512 hashes for binaries
-hash: build
-	@for bin in $(BINARIES); do sha256sum $(TARGET_DIR)/$$bin > $(TARGET_DIR)/$$bin.sha256; sha512sum $(TARGET_DIR)/$$bin > $(TARGET_DIR)/$$bin.sha512; done
+## Generate SHA256 and SHA512 checksums for binaries
+checksum: build
+        cargo run --quiet --bin checksum -- $(addprefix $(TARGET_DIR)/,$(BINARIES))
 
 ## Create an annotated git tag
 # Usage: make tag VERSION=x.y.z
@@ -31,13 +31,13 @@ publish:
 
 ## Run the full release pipeline
 # Usage: make release VERSION=x.y.z [PUBLISH=1]
-release: hash tag push
-	@if [ -n "$(PUBLISH)" ]; then cargo publish; fi
+release: checksum tag push
+        @if [ -n "$(PUBLISH)" ]; then cargo publish; fi
 
 ## Remove build artifacts
 clean:
-	cargo clean
-	rm -f $(TARGET_DIR)/*.sha256 $(TARGET_DIR)/*.sha512
+        cargo clean
+        rm -f checksum/*.sha256 checksum/*.sha512
 
 ## Run tests for all supported database backends
 test: test-sqlite test-postgres test-mysql

--- a/README.md
+++ b/README.md
@@ -103,14 +103,21 @@ the `inventory` crate so they are executed in order after parsing.
 Maintainers can use the provided Makefile to cut releases:
 
 - `make build` – compile optimized binaries.
-- `make hash` – build and emit SHA256/SHA512 checksum files alongside binaries.
+- `make checksum` – write SHA256/SHA512 checksum files to `checksum/`.
 - `make tag VERSION=x.y.z` – create an annotated git tag.
 - `make push VERSION=x.y.z` – push commits and tags to `origin`.
 - `make publish` – publish the crate to crates.io.
-- `make release VERSION=x.y.z [PUBLISH=1]` – run build, hashing, tagging and pushing; set `PUBLISH=1` to also publish the crate.
+- `make release VERSION=x.y.z [PUBLISH=1]` – run build, checksum generation, tagging and pushing; set `PUBLISH=1` to also publish the crate.
 - `make clean` – remove build artifacts.
 - `make test` – run tests against all supported database backends (`make test-sqlite`, `make test-postgres`, `make test-mysql` to run individually).
 - `make notify VERSION=x.y.z WEBHOOK=https://example.com/hook` – send a release announcement to a webhook (e.g. Slack).
+
+Commit the generated files in `checksum/` and reference them in release notes so users can verify downloads:
+
+```bash
+sha256sum -c checksum/risu-rs.sha256
+sha512sum -c checksum/risu-rs.sha512
+```
 
 ## Developer utilities
 

--- a/docs/NEWS.markdown
+++ b/docs/NEWS.markdown
@@ -3,6 +3,7 @@
 ## v0.2.0
 - Restructured documentation and added installation guides.
 - Updated references to Rust build tools.
+- Release artifacts now include SHA256 and SHA512 checksums stored under `checksum/` for verification.
 
 ## v0.1.0
 - Initial release of the Rust rewrite.

--- a/tools/checksum.rs
+++ b/tools/checksum.rs
@@ -1,0 +1,39 @@
+use std::env;
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+use sha2::{Digest, Sha256, Sha512};
+
+fn main() -> io::Result<()> {
+    let paths: Vec<String> = env::args().skip(1).collect();
+    if paths.is_empty() {
+        eprintln!("usage: checksum <file> [file ...]");
+        std::process::exit(1);
+    }
+
+    fs::create_dir_all("checksum")?;
+
+    for path in paths {
+        let mut file = File::open(&path)?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)?;
+
+        let sha256 = Sha256::digest(&buf);
+        let sha512 = Sha512::digest(&buf);
+
+        let name = Path::new(&path)
+            .file_name()
+            .expect("file name")
+            .to_string_lossy();
+
+        let mut out256 = File::create(format!("checksum/{}.sha256", name))?;
+        writeln!(out256, "{:x}  {}", sha256, name)?;
+
+        let mut out512 = File::create(format!("checksum/{}.sha512", name))?;
+        writeln!(out512, "{:x}  {}", sha512, name)?;
+    }
+
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- add cargo binary `checksum` to create SHA256 and SHA512 files in `checksum/`
- integrate `make checksum` into release workflow and document usage
- mention checksums in release notes for verification

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68af98922df08320bc195f5bb10a96d0