### PR TITLE
Add CI workflow and status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        db: [sqlite, postgres, mysql]
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: risu
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 10s --health-timeout 5s --health-retries 5
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_USER: mysql
+          MYSQL_PASSWORD: mysql
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_DATABASE: risu
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - name: Set up DATABASE_URL
+        run: |
+          if [ "${{ matrix.db }}" = "sqlite" ]; then
+            echo "DATABASE_URL=sqlite://:memory:" >> $GITHUB_ENV
+          elif [ "${{ matrix.db }}" = "postgres" ]; then
+            echo "DATABASE_URL=postgres://postgres:postgres@localhost:5432/risu" >> $GITHUB_ENV
+          else
+            echo "DATABASE_URL=mysql://mysql:mysql@localhost:3306/risu" >> $GITHUB_ENV
+          fi
+      - name: Install database client libraries
+        run: |
+          if [ "${{ matrix.db }}" = "postgres" ]; then
+            sudo apt-get update
+            sudo apt-get install -y libpq-dev postgresql-client
+          elif [ "${{ matrix.db }}" = "mysql" ]; then
+            sudo apt-get update
+            sudo apt-get install -y libmysqlclient-dev
+          fi
+      - name: Cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Cargo clippy
+        run: cargo clippy --no-default-features --features ${{ matrix.db }} -- -D warnings
+      - name: Cargo test
+        run: cargo test --no-default-features --features ${{ matrix.db }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # risu-rs
 
+[![CI](https://github.com/example/risu-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/example/risu-rs/actions/workflows/ci.yml)
+
 A Rust rewrite of the Risu reporting utilities.
 
 ## Documentation


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` across sqlite, PostgreSQL, and MySQL backends
- document CI status badge in README

## Testing
- `cargo fmt --all -- --check` (fails: shows formatting diffs)
- `cargo clippy -- -D warnings` (fails: clippy errors)
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68afb43e5bc883209d7a2d3e8b45e041