### PR TITLE
Add rollup tests for Cisco IOS and VMware vCenter

### DIFF
--- a/tests/postprocess.rs
+++ b/tests/postprocess.rs
@@ -152,3 +152,51 @@ fn php_rollup_creates_summary_item() {
     );
 }
 
+#[test]
+fn cisco_ios_rollup_creates_summary_item() {
+    let mut item = Item::default();
+    item.plugin_id = Some(58568);
+    item.severity = Some(3);
+    let mut report = NessusReport {
+        items: vec![item],
+        ..NessusReport::default()
+    };
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
+    // original item downgraded
+    let orig = report.items.iter().find(|i| i.plugin_id == Some(58568)).unwrap();
+    assert_eq!(orig.severity, Some(-1));
+    assert_eq!(orig.real_severity, Some(3));
+    // rollup plugin and item inserted
+    assert!(report.plugins.iter().any(|p| p.plugin_id == Some(-99965)));
+    assert!(
+        report
+            .items
+            .iter()
+            .any(|i| i.plugin_id == Some(-99965) && i.severity == Some(3))
+    );
+}
+
+#[test]
+fn vmware_vcenter_rollup_creates_summary_item() {
+    let mut item = Item::default();
+    item.plugin_id = Some(79865);
+    item.severity = Some(4);
+    let mut report = NessusReport {
+        items: vec![item],
+        ..NessusReport::default()
+    };
+    postprocess::process(&mut report, &HashSet::new(), &HashSet::new(), &Filters::default());
+    // original item downgraded
+    let orig = report.items.iter().find(|i| i.plugin_id == Some(79865)).unwrap();
+    assert_eq!(orig.severity, Some(-1));
+    assert_eq!(orig.real_severity, Some(4));
+    // rollup plugin and item inserted
+    assert!(report.plugins.iter().any(|p| p.plugin_id == Some(-99979)));
+    assert!(
+        report
+            .items
+            .iter()
+            .any(|i| i.plugin_id == Some(-99979) && i.severity == Some(4))
+    );
+}
+


### PR DESCRIPTION
## Summary
- test Cisco IOS rollup inserts summary item and downgrades original
- test VMware vCenter rollup inserts summary item and downgrades original

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68afbe952674832095b69675e9a4c56b